### PR TITLE
fix: address issues #1-#6 and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ ccdock help     # show help
 | ---- | ------ | ----------- |
 | `●` green | running | Agent is executing tools |
 | `●`/`○` yellow pulse | waiting | Awaiting user permission |
-| `○` teal | idle | Agent is ready |
+| `○` gray | idle | Agent started but hasn't done anything yet |
+| `●` teal | stopped | Agent finished its turn (Stop event received) |
 
 ## How it works
 

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "cchub",
+      "dependencies": {
+        "ccdock": "^0.1.1",
+      },
       "devDependencies": {
         "@biomejs/biome": "^1.9.0",
         "@types/bun": "latest",
@@ -37,6 +40,8 @@
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+
+    "ccdock": ["ccdock@0.1.2", "", { "dependencies": { "ccdock": "^0.1.1" }, "peerDependencies": { "typescript": "^5" }, "os": "darwin", "bin": { "ccdock": "src/main.ts" } }, "sha512-0K9uPmTED9IzLZyuJClczxdDs4CzGmo70CfuhgMEghFNKsl4ApkRQsQBnaf4aSdD34EZa+Hrq7n+0ijXVjuAQQ=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "dev": "bun run src/main.ts",
     "build": "bun build --compile src/main.ts --outfile ccdock",
     "typecheck": "bunx tsc --noEmit",
-    "format": "bunx @biomejs/biome format --write src/"
+    "format": "bunx @biomejs/biome format --write src/ test/",
+    "test": "bun test"
   },
   "keywords": [
     "claude-code",

--- a/src/agent/hook.ts
+++ b/src/agent/hook.ts
@@ -60,7 +60,7 @@ const STATUS_MAP: Record<string, string> = {
 	PostToolUse: "running",
 	SubagentToolUse: "running",
 	PermissionRequest: "waiting",
-	Stop: "idle",
+	Stop: "stopped",
 	SessionEnd: "remove",
 };
 
@@ -108,10 +108,10 @@ export async function handleHook(agentType: string, eventName: string): Promise<
 	const rawToolDetail = extractToolDetail(rawToolName, toolInput);
 
 	// Preserve previous toolName/toolDetail only for events that don't carry tool info
-	// but clear them on Stop (idle) since the agent is no longer doing anything
+	// but clear them on Stop (stopped) since the agent is no longer doing anything
 	let toolName = rawToolName;
 	let toolDetail = rawToolDetail;
-	if (!toolName && status !== "idle") {
+	if (!toolName && status !== "stopped") {
 		const prev = readAgentState(filename);
 		if (prev) {
 			toolName = prev.toolName ?? "";

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -7,6 +7,7 @@ import {
 	closeEditorWindow,
 	listEditorWindows,
 	getFocusedEditorWindow,
+	windowMatchesWorktree,
 } from "./workspace/window.ts";
 import { disableRawMode, enableRawMode, parseKey, parseKeyWizard } from "./tui/input.ts";
 import { renderSidebar } from "./tui/render.ts";
@@ -20,7 +21,13 @@ import {
 	loadSessions,
 	saveSession,
 } from "./workspace/state.ts";
-import { createWorktree, listWorktrees, removeWorktree } from "./worktree/manager.ts";
+import {
+	createWorktree,
+	createWorktreeFromRemote,
+	listWorktrees,
+	removeWorktree,
+} from "./worktree/manager.ts";
+import { listRemoteBranches } from "./worktree/remote.ts";
 import { scanRepos } from "./worktree/scanner.ts";
 
 function sessionNameFromBranch(branchName: string): string {
@@ -43,6 +50,7 @@ function createInitialState(): SidebarState {
 		wizard: null,
 		deleteConfirm: null,
 		quitConfirm: null,
+		deletingSessionIds: new Set(),
 	};
 }
 
@@ -65,8 +73,12 @@ async function refreshSessions(state: SidebarState): Promise<void> {
 
 	for (const session of sessions) {
 		const basename = session.worktreePath.split("/").pop() ?? "";
-		const hasWindow = editorWindows.some((w) => w.includes(basename));
-		if (hasWindow && focusedEditor.isFrontmost && focusedEditor.frontWindow.includes(basename)) {
+		const hasWindow = editorWindows.some((w) => windowMatchesWorktree(w, basename));
+		if (
+			hasWindow &&
+			focusedEditor.isFrontmost &&
+			windowMatchesWorktree(focusedEditor.frontWindow, basename)
+		) {
 			session.editorState = "focused";
 		} else if (hasWindow) {
 			session.editorState = "open";
@@ -178,18 +190,29 @@ async function handleWizardInput(
 					wizard.selectedIndex = Math.max(0, wizard.selectedIndex - 1);
 					break;
 				case "down":
-					wizard.selectedIndex = Math.min(2, wizard.selectedIndex + 1);
+					wizard.selectedIndex = Math.min(3, wizard.selectedIndex + 1);
 					break;
 				case "enter":
 					if (wizard.selectedIndex === 0) {
-						// Create new worktree (git wt)
+						// Create new worktree (git wt) — ask about fetch first
 						state.wizard = {
-							step: "enter-branch",
+							step: "fetch-choice",
 							repo: wizard.repo,
-							branchName: "",
+							selectedIndex: 0,
 							repos: wizard.repos,
 						};
 					} else if (wizard.selectedIndex === 1) {
+						// From remote branch — fetch and show remote branches
+						const branches = await listRemoteBranches(wizard.repo.path);
+						state.wizard = {
+							step: "select-remote-branch",
+							repo: wizard.repo,
+							branches,
+							selectedIndex: 0,
+							filter: "",
+							repos: wizard.repos,
+						};
+					} else if (wizard.selectedIndex === 2) {
 						// Use existing worktree
 						const worktrees = await listWorktrees(wizard.repo.path);
 						state.wizard = {
@@ -199,7 +222,7 @@ async function handleWizardInput(
 							selectedIndex: 0,
 							repos: wizard.repos,
 						};
-					} else if (wizard.selectedIndex === 2) {
+					} else if (wizard.selectedIndex === 3) {
 						// Open repository root
 						await createSessionFromPath(
 							wizard.repo,
@@ -243,7 +266,35 @@ async function handleWizardInput(
 					state.wizard = {
 						step: "select-mode",
 						repo: wizard.repo,
-						selectedIndex: 1,
+						selectedIndex: 2,
+						repos: wizard.repos,
+					};
+					break;
+			}
+			break;
+		}
+		case "fetch-choice": {
+			switch (key.type) {
+				case "up":
+					wizard.selectedIndex = Math.max(0, wizard.selectedIndex - 1);
+					break;
+				case "down":
+					wizard.selectedIndex = Math.min(1, wizard.selectedIndex + 1);
+					break;
+				case "enter":
+					state.wizard = {
+						step: "enter-branch",
+						repo: wizard.repo,
+						branchName: "",
+						fetchBeforeCreate: wizard.selectedIndex === 0,
+						repos: wizard.repos,
+					};
+					break;
+				case "escape":
+					state.wizard = {
+						step: "select-mode",
+						repo: wizard.repo,
+						selectedIndex: 0,
 						repos: wizard.repos,
 					};
 					break;
@@ -254,7 +305,12 @@ async function handleWizardInput(
 			switch (key.type) {
 				case "enter": {
 					if (wizard.branchName.trim()) {
-						await createSession(wizard.repo, wizard.branchName.trim(), config.editor);
+						await createSession(
+							wizard.repo,
+							wizard.branchName.trim(),
+							config.editor,
+							wizard.fetchBeforeCreate,
+						);
 						state.wizard = null;
 						refreshSessions(state);
 					}
@@ -262,9 +318,9 @@ async function handleWizardInput(
 				}
 				case "escape":
 					state.wizard = {
-						step: "select-mode",
+						step: "fetch-choice",
 						repo: wizard.repo,
-						selectedIndex: 0,
+						selectedIndex: wizard.fetchBeforeCreate ? 0 : 1,
 						repos: wizard.repos,
 					};
 					break;
@@ -273,6 +329,88 @@ async function handleWizardInput(
 					break;
 				case "char":
 					wizard.branchName += key.char;
+					break;
+			}
+			break;
+		}
+		case "select-remote-branch": {
+			const filteredBranches = wizard.branches.filter((b) =>
+				b.toLowerCase().includes(wizard.filter.toLowerCase()),
+			);
+			switch (key.type) {
+				case "up":
+					wizard.selectedIndex = Math.max(0, wizard.selectedIndex - 1);
+					break;
+				case "down":
+					wizard.selectedIndex = Math.min(
+						Math.max(0, filteredBranches.length - 1),
+						wizard.selectedIndex + 1,
+					);
+					break;
+				case "enter": {
+					const selected = filteredBranches[wizard.selectedIndex];
+					if (selected) {
+						state.wizard = {
+							step: "enter-local-branch",
+							repo: wizard.repo,
+							remoteRef: selected,
+							localBranch: selected.replace(/^origin\//, ""),
+							repos: wizard.repos,
+						};
+					}
+					break;
+				}
+				case "escape":
+					state.wizard = {
+						step: "select-mode",
+						repo: wizard.repo,
+						selectedIndex: 1,
+						repos: wizard.repos,
+					};
+					break;
+				case "backspace":
+					wizard.filter = wizard.filter.slice(0, -1);
+					wizard.selectedIndex = 0;
+					break;
+				case "char":
+					wizard.filter += key.char;
+					wizard.selectedIndex = 0;
+					break;
+			}
+			break;
+		}
+		case "enter-local-branch": {
+			switch (key.type) {
+				case "enter": {
+					if (wizard.localBranch.trim()) {
+						await createSessionFromRemote(
+							wizard.repo,
+							wizard.localBranch.trim(),
+							wizard.remoteRef,
+							config.editor,
+						);
+						state.wizard = null;
+						refreshSessions(state);
+					}
+					break;
+				}
+				case "escape":
+					state.wizard = {
+						step: "select-remote-branch",
+						repo: wizard.repo,
+						branches: [],
+						selectedIndex: 0,
+						filter: "",
+						repos: wizard.repos,
+					};
+					// re-fetch branches lazily — simpler to re-run the list now
+					state.wizard.branches = await listRemoteBranches(wizard.repo.path);
+					break;
+				case "backspace":
+					wizard.localBranch = wizard.localBranch.slice(0, -1);
+					break;
+				case "char":
+					wizard.localBranch += key.char;
 					break;
 			}
 			break;
@@ -307,13 +445,36 @@ async function createSessionFromPath(
 	}
 }
 
-async function createSession(repo: RepoInfo, branchName: string, editor: string): Promise<void> {
+async function createSession(
+	repo: RepoInfo,
+	branchName: string,
+	editor: string,
+	fetchBeforeCreate: boolean,
+): Promise<void> {
 	try {
-		const worktreePath = await createWorktree(repo.path, branchName);
+		const worktreePath = await createWorktree(repo.path, branchName, {
+			fetch: fetchBeforeCreate,
+			base: repo.defaultBranch,
+		});
 		await createSessionFromPath(repo, worktreePath, branchName, editor);
 	} catch (err) {
 		const msg = err instanceof Error ? err.message : "Unknown error";
 		process.stderr.write(`\nError creating session: ${msg}\n`);
+	}
+}
+
+async function createSessionFromRemote(
+	repo: RepoInfo,
+	localBranch: string,
+	remoteRef: string,
+	editor: string,
+): Promise<void> {
+	try {
+		const worktreePath = await createWorktreeFromRemote(repo.path, localBranch, remoteRef);
+		await createSessionFromPath(repo, worktreePath, localBranch, editor);
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : "Unknown error";
+		process.stderr.write(`\nError creating session from remote: ${msg}\n`);
 	}
 }
 
@@ -331,24 +492,46 @@ async function handleDeleteConfirmInput(state: SidebarState, data: Buffer): Prom
 			confirm.selectedIndex = Math.min(1, confirm.selectedIndex + 1);
 			break;
 		case "enter": {
-			// Close the VS Code window for this session
-			const basename = confirm.worktreePath.split("/").pop() ?? "";
-			await closeEditorWindow(basename);
-
-			// Delete session state
-			deleteSession(confirm.sessionId);
-
-			if (confirm.selectedIndex === 1) {
-				// Also remove worktree
-				try {
-					await removeWorktree(confirm.worktreePath);
-				} catch {
-					// Worktree might already be removed or busy
-				}
-			}
-
+			const { sessionId, worktreePath, selectedIndex } = confirm;
+			const removeWorktreeToo = selectedIndex === 1;
+			// Close the confirm modal immediately and mark the card as deleting
 			state.deleteConfirm = null;
-			refreshSessions(state);
+			state.deletingSessionIds.add(sessionId);
+			render(state);
+
+			// Perform the actual deletion asynchronously so the spinner stays responsive
+			void (async () => {
+				try {
+					const basename = worktreePath.split("/").pop() ?? "";
+					await closeEditorWindow(basename);
+					deleteSession(sessionId);
+
+					if (removeWorktreeToo) {
+						try {
+							await removeWorktree(worktreePath);
+						} catch (err) {
+							const msg = err instanceof Error ? err.message : "Unknown error";
+							state.activityLog.push({
+								time: new Date().toLocaleTimeString("en-US", {
+									hour12: false,
+									hour: "2-digit",
+									minute: "2-digit",
+									second: "2-digit",
+								}),
+								sessionId,
+								sessionIndex: -1,
+								agent: "ccdock",
+								tool: "[error]",
+								toolDetail: `worktree remove failed: ${msg}`,
+							});
+						}
+					}
+				} finally {
+					state.deletingSessionIds.delete(sessionId);
+					await refreshSessions(state);
+					render(state);
+				}
+			})();
 			break;
 		}
 		case "escape":
@@ -357,7 +540,7 @@ async function handleDeleteConfirmInput(state: SidebarState, data: Buffer): Prom
 	}
 }
 
-function getManagedEditorTitles(sessions: SidebarState["sessions"]): string[] {
+function getManagedEditorBasenames(sessions: SidebarState["sessions"]): string[] {
 	return sessions
 		.filter((s) => s.editorState !== "closed")
 		.map((s) => s.worktreePath.split("/").pop() ?? "")
@@ -381,7 +564,7 @@ export async function runSidebar(): Promise<void> {
 		state.rows = process.stdout.rows ?? 24;
 		state.cols = process.stdout.columns ?? 80;
 		render(state);
-		await repositionAllEditors(getManagedEditorTitles(state.sessions));
+		await repositionAllEditors(getManagedEditorBasenames(state.sessions));
 	});
 
 	// Animation timer (200ms) — only repaint when there's something animating
@@ -392,7 +575,13 @@ export async function runSidebar(): Promise<void> {
 				s.editorState === "launching" ||
 				s.agents.some((a) => a.status === "running" || a.status === "waiting"),
 		);
-		if (hasAnimated || state.wizard || state.deleteConfirm || state.quitConfirm) {
+		if (
+			hasAnimated ||
+			state.wizard ||
+			state.deleteConfirm ||
+			state.quitConfirm ||
+			state.deletingSessionIds.size > 0
+		) {
 			render(state);
 		}
 	}, 200);
@@ -477,7 +666,7 @@ export async function runSidebar(): Promise<void> {
 			case "enter":
 			case "tab": {
 				const session = state.sessions[state.selectedIndex];
-				if (session) {
+				if (session && !state.deletingSessionIds.has(session.id)) {
 					const focused = await focusEditor(session.worktreePath, config.editor);
 					if (!focused) {
 						// Show launching state while VS Code opens
@@ -503,7 +692,7 @@ export async function runSidebar(): Promise<void> {
 
 			case "delete": {
 				const session = state.sessions[state.selectedIndex];
-				if (session) {
+				if (session && !state.deletingSessionIds.has(session.id)) {
 					state.deleteConfirm = {
 						sessionId: session.id,
 						worktreePath: session.worktreePath,
@@ -522,7 +711,7 @@ export async function runSidebar(): Promise<void> {
 				break;
 
 			case "realign":
-				await repositionAllEditors(getManagedEditorTitles(state.sessions));
+				await repositionAllEditors(getManagedEditorBasenames(state.sessions));
 				break;
 
 			case "mouse_click": {
@@ -532,7 +721,7 @@ export async function runSidebar(): Promise<void> {
 				if (clicked) {
 					state.selectedIndex = clicked.sessionIndex;
 					const session = state.sessions[clicked.sessionIndex];
-					if (session) {
+					if (session && !state.deletingSessionIds.has(session.id)) {
 						const focused = await focusEditor(session.worktreePath, config.editor);
 						if (!focused) {
 							session.editorState = "launching";

--- a/src/tui/ansi.ts
+++ b/src/tui/ansi.ts
@@ -26,7 +26,8 @@ export function bg256(code: number): string {
 export const COLORS = {
 	running: fg256(82), // bright green
 	waiting: fg256(220), // yellow/orange
-	idle: fg256(73), // teal
+	idle: fg256(245), // muted gray — started but no activity yet
+	stopped: fg256(73), // teal — completed work (Stop event received)
 	error: fg256(196), // red
 	unknown: fg256(245), // gray
 
@@ -59,6 +60,8 @@ export function statusColor(status: string): string {
 			return COLORS.waiting;
 		case "idle":
 			return COLORS.idle;
+		case "stopped":
+			return COLORS.stopped;
 		case "error":
 			return COLORS.error;
 		default:
@@ -75,7 +78,9 @@ export function statusIcon(status: string, frame: number): string {
 		case "waiting":
 			return pulse ? "\u25cf" : "\u25cb";
 		case "idle":
-			return "\u25cb"; // ○
+			return "\u25cb"; // ○ — not started / no activity
+		case "stopped":
+			return "\u25cf"; // ● — completed
 		case "error":
 			return "\u25cf"; // ●
 		default:

--- a/src/tui/input.ts
+++ b/src/tui/input.ts
@@ -21,9 +21,31 @@ export type WizardKeyAction =
 	| { type: "char"; char: string }
 	| { type: "unknown" };
 
+/**
+ * Normalize fullwidth ASCII letters / digits / symbols (U+FF01–U+FF5E)
+ * to halfwidth so that keyboard shortcuts still fire while a Japanese IME
+ * is active. Also maps the fullwidth space (U+3000) to a regular space.
+ * Non-ASCII runes outside this range are passed through unchanged.
+ */
+export function normalizeFullwidth(s: string): string {
+	let out = "";
+	for (const ch of s) {
+		const code = ch.charCodeAt(0);
+		if (code >= 0xff01 && code <= 0xff5e) {
+			out += String.fromCharCode(code - 0xfee0);
+		} else if (code === 0x3000) {
+			out += " ";
+		} else {
+			out += ch;
+		}
+	}
+	return out;
+}
+
 export function parseKey(data: Buffer): KeyAction {
 	// SGR mouse: \x1b[<button;col;rowM (press) or \x1b[<button;col;rowm (release)
-	const s = data.toString();
+	const raw = data.toString();
+	const s = normalizeFullwidth(raw);
 	const sgrMatch = s.match(/^\x1b\[<(\d+);(\d+);(\d+)([Mm])$/);
 	if (sgrMatch) {
 		const button = Number.parseInt(sgrMatch[1]!, 10);
@@ -72,7 +94,8 @@ export function parseKey(data: Buffer): KeyAction {
 }
 
 export function parseKeyWizard(data: Buffer): WizardKeyAction {
-	const s = data.toString();
+	const raw = data.toString();
+	const s = normalizeFullwidth(raw);
 
 	// Escape sequences for arrow keys
 	if (s === "\x1b[A") return { type: "up" };

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -68,6 +68,7 @@ function renderCard(
 	compact: boolean,
 	deleteConfirm: DeleteConfirm | null,
 	sessionIndex: number,
+	isDeleting: boolean,
 ): string[] {
 	const lines: string[] = [];
 	const width = Math.max(cols - 2, 20);
@@ -76,21 +77,24 @@ function renderCard(
 	// Focused: white border, normal title
 	// Open: normal border + green ● dot
 	// Closed: dim everything
+	// Deleting: error-colored border, spinner
 	const editorState = session.editorState;
 	const isFocused = editorState === "focused";
 	const isClosed = editorState === "closed";
 	const isLaunching = editorState === "launching";
-	// Border color: VS Code focused > J/K selected > closed/open
-	const borderColor = isFocused
-		? COLORS.borderFocused
-		: isSelected
-			? COLORS.borderSelected
-			: isClosed
-				? COLORS.borderClosed
-				: COLORS.border;
-	const titleColor = isClosed ? COLORS.editorClosed : COLORS.title;
+	// Border color: Deleting > VS Code focused > J/K selected > closed/open
+	const borderColor = isDeleting
+		? COLORS.error
+		: isFocused
+			? COLORS.borderFocused
+			: isSelected
+				? COLORS.borderSelected
+				: isClosed
+					? COLORS.borderClosed
+					: COLORS.border;
+	const titleColor = isDeleting ? COLORS.error : isClosed ? COLORS.editorClosed : COLORS.title;
 	const detailColor = isClosed ? COLORS.editorClosed : COLORS.subtitle;
-	const dimAll = isClosed ? DIM : "";
+	const dimAll = isClosed && !isDeleting ? DIM : "";
 
 	// Status dot: spinning for launching, green solid for open/focused, none for closed
 	let openDot = "";
@@ -122,8 +126,12 @@ function renderCard(
 		const pathLine = `${dimAll}${borderColor}${BOX.vertical}${RESET} ${pathColor}${padRight(pathTruncated, width - 4)}${RESET} ${dimAll}${borderColor}${BOX.vertical}${RESET}`;
 		lines.push(pathLine);
 
-		// Agent status lines
-		if (session.agents.length === 0) {
+		if (isDeleting) {
+			const frame = SPINNER_FRAMES[animFrame % SPINNER_FRAMES.length]!;
+			const deleteText = `${COLORS.error}${frame} Deleting session...${RESET}`;
+			const deleteLine = `${dimAll}${borderColor}${BOX.vertical}${RESET} ${padRight(deleteText, width - 4)}${RESET} ${dimAll}${borderColor}${BOX.vertical}${RESET}`;
+			lines.push(deleteLine);
+		} else if (session.agents.length === 0) {
 			const noAgent = `${DIM}no agents${RESET}`;
 			const agentLine = `${dimAll}${borderColor}${BOX.vertical}${RESET} ${padRight(noAgent, width - 4)}${RESET} ${dimAll}${borderColor}${BOX.vertical}${RESET}`;
 			lines.push(agentLine);
@@ -149,12 +157,17 @@ function renderCard(
 		}
 	} else {
 		// Compact: just show agent status inline
-		const agentSummary =
-			session.agents.length > 0
-				? session.agents
-						.map((a) => `${statusColor(a.status)}${statusIcon(a.status, animFrame)}${RESET}`)
-						.join(" ")
-				: `${DIM}no agents${RESET}`;
+		let agentSummary: string;
+		if (isDeleting) {
+			const frame = SPINNER_FRAMES[animFrame % SPINNER_FRAMES.length]!;
+			agentSummary = `${COLORS.error}${frame} deleting${RESET}`;
+		} else if (session.agents.length > 0) {
+			agentSummary = session.agents
+				.map((a) => `${statusColor(a.status)}${statusIcon(a.status, animFrame)}${RESET}`)
+				.join(" ");
+		} else {
+			agentSummary = `${DIM}no agents${RESET}`;
+		}
 		const compactLine = `${dimAll}${borderColor}${BOX.vertical}${RESET} ${padRight(agentSummary, width - 4)}${RESET} ${dimAll}${borderColor}${BOX.vertical}${RESET}`;
 		lines.push(compactLine);
 	}
@@ -279,6 +292,7 @@ export function renderSidebar(state: SidebarState): string {
 			state.compactMode,
 			state.deleteConfirm,
 			i,
+			state.deletingSessionIds.has(session.id),
 		);
 
 		if (linesUsed + cardLines.length > availableForCards) break;

--- a/src/tui/wizard.ts
+++ b/src/tui/wizard.ts
@@ -55,6 +55,10 @@ function renderModeSelect(repo: RepoInfo, selectedIndex: number, cols: number): 
 
 	const modes = [
 		{ label: "Create new worktree (git wt)", desc: "Create a new feature branch worktree" },
+		{
+			label: "Create worktree from remote branch",
+			desc: "Check out an existing origin/* branch",
+		},
 		{ label: "Use existing worktree", desc: "Select from existing worktrees" },
 		{ label: "Open repository root", desc: "Open the main repository directory" },
 	];
@@ -113,13 +117,19 @@ function renderWorktreeList(
 	return lines;
 }
 
-function renderBranchInput(repo: RepoInfo, branchName: string, cols: number): string[] {
+function renderBranchInput(
+	repo: RepoInfo,
+	branchName: string,
+	fetchBeforeCreate: boolean,
+	cols: number,
+): string[] {
 	const lines: string[] = [];
 	const width = Math.max(cols - 4, 20);
 
 	lines.push(`${BOLD}${COLORS.highlight} Create Session: ${repo.name}${RESET}`);
 	lines.push("");
-	lines.push(`${COLORS.muted}  Enter branch name:${RESET}`);
+	const fetchLabel = fetchBeforeCreate ? "fetch origin first" : "no fetch";
+	lines.push(`${COLORS.muted}  Enter branch name (${fetchLabel}):${RESET}`);
 	lines.push("");
 	lines.push(`  ${COLORS.border}${BOX.horizontal.repeat(width - 6)}${RESET}`);
 	lines.push(`  ${BOLD}${branchName}${RESET}\u2588`);
@@ -128,6 +138,117 @@ function renderBranchInput(repo: RepoInfo, branchName: string, cols: number): st
 
 	if (branchName) {
 		const preview = `${repo.name}--${branchName.replace(/\//g, "-")}`;
+		lines.push(`${COLORS.muted}  Worktree dir: ${preview}${RESET}`);
+	}
+
+	lines.push("");
+	lines.push(`${COLORS.muted}  Enter: create | Esc: back${RESET}`);
+
+	return lines;
+}
+
+function renderFetchChoice(repo: RepoInfo, selectedIndex: number, cols: number): string[] {
+	const lines: string[] = [];
+	const width = Math.max(cols - 4, 20);
+
+	lines.push(`${BOLD}${COLORS.highlight} Create Session: ${repo.name}${RESET}`);
+	lines.push("");
+	lines.push(`${COLORS.muted}  Refresh ${repo.defaultBranch} from origin before creating?${RESET}`);
+	lines.push("");
+
+	const options = [
+		{
+			label: `Fetch latest origin/${repo.defaultBranch} first`,
+			desc: "Runs `git fetch origin` before git wt",
+		},
+		{ label: "Create without fetching", desc: "Use local refs as-is" },
+	];
+
+	for (let i = 0; i < options.length; i++) {
+		const opt = options[i];
+		if (!opt) continue;
+		const isSelected = i === selectedIndex;
+		const marker = isSelected ? `${COLORS.highlight}\u25b6${RESET}` : " ";
+		const label = isSelected
+			? `${BOLD}${COLORS.title}${opt.label}${RESET}`
+			: `${COLORS.subtitle}${opt.label}${RESET}`;
+		const desc = `${COLORS.muted}${opt.desc}${RESET}`;
+		lines.push(truncate(` ${marker} ${label}`, width));
+		lines.push(truncate(`     ${desc}`, width));
+	}
+
+	lines.push("");
+	lines.push(`${COLORS.muted}  j/k: navigate | Enter: select | Esc: back${RESET}`);
+
+	return lines;
+}
+
+function renderRemoteBranchList(
+	repo: RepoInfo,
+	branches: string[],
+	selectedIndex: number,
+	filter: string,
+	cols: number,
+): string[] {
+	const lines: string[] = [];
+	const width = Math.max(cols - 4, 20);
+
+	lines.push(`${BOLD}${COLORS.highlight} Select Remote Branch: ${repo.name}${RESET}`);
+	lines.push(`${COLORS.muted}  (local cache — run \`git fetch\` in a shell to refresh)${RESET}`);
+	lines.push("");
+
+	if (filter) {
+		lines.push(`${COLORS.muted}  Filter: ${RESET}${filter}`);
+		lines.push("");
+	}
+
+	const filtered = branches.filter((b) => b.toLowerCase().includes(filter.toLowerCase()));
+
+	if (filtered.length === 0) {
+		lines.push(
+			`${DIM}  ${branches.length === 0 ? "No remote branches in local cache." : `No branches matching "${filter}"`}${RESET}`,
+		);
+	} else {
+		for (let i = 0; i < filtered.length; i++) {
+			const branch = filtered[i];
+			if (!branch) continue;
+			const isSelected = i === selectedIndex;
+			const marker = isSelected ? `${COLORS.highlight}\u25b6${RESET}` : " ";
+			const label = isSelected
+				? `${BOLD}${COLORS.title}${branch}${RESET}`
+				: `${COLORS.subtitle}${branch}${RESET}`;
+			lines.push(truncate(` ${marker} ${label}`, width));
+		}
+	}
+
+	lines.push("");
+	lines.push(`${COLORS.muted}  j/k: navigate | Enter: select | Esc: back${RESET}`);
+	lines.push(`${COLORS.muted}  Type to filter branches${RESET}`);
+
+	return lines;
+}
+
+function renderLocalBranchInput(
+	repo: RepoInfo,
+	remoteRef: string,
+	localBranch: string,
+	cols: number,
+): string[] {
+	const lines: string[] = [];
+	const width = Math.max(cols - 4, 20);
+
+	lines.push(`${BOLD}${COLORS.highlight} Create Session: ${repo.name}${RESET}`);
+	lines.push("");
+	lines.push(`${COLORS.muted}  From: ${remoteRef}${RESET}`);
+	lines.push(`${COLORS.muted}  Enter local branch name:${RESET}`);
+	lines.push("");
+	lines.push(`  ${COLORS.border}${BOX.horizontal.repeat(width - 6)}${RESET}`);
+	lines.push(`  ${BOLD}${localBranch}${RESET}\u2588`);
+	lines.push(`  ${COLORS.border}${BOX.horizontal.repeat(width - 6)}${RESET}`);
+	lines.push("");
+
+	if (localBranch) {
+		const preview = `${repo.name}--${localBranch.replace(/\//g, "-")}`;
 		lines.push(`${COLORS.muted}  Worktree dir: ${preview}${RESET}`);
 	}
 
@@ -155,8 +276,23 @@ export function renderWizard(wizard: WizardState, cols: number): string {
 		case "select-worktree":
 			content = renderWorktreeList(wizard.repo, wizard.worktrees, wizard.selectedIndex, cols);
 			break;
+		case "fetch-choice":
+			content = renderFetchChoice(wizard.repo, wizard.selectedIndex, cols);
+			break;
 		case "enter-branch":
-			content = renderBranchInput(wizard.repo, wizard.branchName, cols);
+			content = renderBranchInput(wizard.repo, wizard.branchName, wizard.fetchBeforeCreate, cols);
+			break;
+		case "select-remote-branch":
+			content = renderRemoteBranchList(
+				wizard.repo,
+				wizard.branches,
+				wizard.selectedIndex,
+				wizard.filter,
+				cols,
+			);
+			break;
+		case "enter-local-branch":
+			content = renderLocalBranchInput(wizard.repo, wizard.remoteRef, wizard.localBranch, cols);
 			break;
 	}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 export type AgentType = "claude-code" | "codex";
-export type AgentStatus = "running" | "waiting" | "idle" | "error" | "unknown";
+export type AgentStatus = "running" | "waiting" | "idle" | "stopped" | "error" | "unknown";
 
 export interface AgentState {
 	sessionId: string;
@@ -63,6 +63,7 @@ export interface SidebarState {
 	wizard: WizardState;
 	deleteConfirm: DeleteConfirm | null;
 	quitConfirm: { selectedIndex: number } | null; // 0=quit only, 1=quit+close editors
+	deletingSessionIds: Set<string>;
 }
 
 // Wizard steps for creating new sessions
@@ -76,7 +77,29 @@ export type WizardStep =
 			selectedIndex: number;
 			repos: RepoInfo[];
 	  }
-	| { step: "enter-branch"; repo: RepoInfo; branchName: string; repos: RepoInfo[] };
+	| { step: "fetch-choice"; repo: RepoInfo; selectedIndex: number; repos: RepoInfo[] }
+	| {
+			step: "enter-branch";
+			repo: RepoInfo;
+			branchName: string;
+			fetchBeforeCreate: boolean;
+			repos: RepoInfo[];
+	  }
+	| {
+			step: "select-remote-branch";
+			repo: RepoInfo;
+			branches: string[];
+			selectedIndex: number;
+			filter: string;
+			repos: RepoInfo[];
+	  }
+	| {
+			step: "enter-local-branch";
+			repo: RepoInfo;
+			remoteRef: string;
+			localBranch: string;
+			repos: RepoInfo[];
+	  };
 
 export type WizardState = WizardStep | null;
 

--- a/src/workspace/state.ts
+++ b/src/workspace/state.ts
@@ -10,7 +10,10 @@ import { join } from "node:path";
 import type { AgentState, WorkspaceSession } from "../types.ts";
 
 const STATE_DIR_NAME = "ccdock";
-const STALE_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
+// Agents in a transient state (running/waiting) are staled after 30 minutes
+// without updates. "stopped" (Stop event received) and "idle" (no work yet)
+// are never staled so completed/ready sessions stay visible indefinitely.
+const STALE_TRANSIENT_THRESHOLD_MS = 30 * 60 * 1000;
 
 export function getStateDir(): string {
 	const home = process.env.HOME ?? "";
@@ -100,13 +103,29 @@ export function cleanStaleAgents(): void {
 	const agentsDir = getAgentsDir();
 	const files = readdirSync(agentsDir).filter((f) => f.endsWith(".json"));
 	const now = Date.now();
+	const sessions = loadSessions();
+	const sessionPaths = sessions.map((s) => s.worktreePath);
+	const sessionIds = new Set(sessions.map((s) => s.id));
 
 	for (const file of files) {
 		try {
 			const filePath = join(agentsDir, file);
 			const raw = readFileSync(filePath, "utf-8");
 			const parsed = JSON.parse(raw) as AgentState;
-			if (now - parsed.updatedAt > STALE_THRESHOLD_MS) {
+
+			// Orphan check: agent belongs to no known session (neither by id nor by cwd prefix)
+			const hasSession =
+				(parsed.sessionId && sessionIds.has(parsed.sessionId)) ||
+				sessionPaths.some((p) => parsed.cwd.startsWith(p));
+			if (!hasSession) {
+				unlinkSync(filePath);
+				continue;
+			}
+
+			// "stopped" (completed) and "idle" (not yet started) are preserved indefinitely
+			if (parsed.status === "stopped" || parsed.status === "idle") continue;
+
+			if (now - parsed.updatedAt > STALE_TRANSIENT_THRESHOLD_MS) {
 				unlinkSync(filePath);
 			}
 		} catch {

--- a/src/workspace/window.ts
+++ b/src/workspace/window.ts
@@ -10,13 +10,37 @@ interface WindowBounds {
 	height: number;
 }
 
+/**
+ * Strict match between a VS Code window title and a worktree basename.
+ * VS Code titles look like "<file> — <workspace>" or "<workspace> — Visual Studio Code",
+ * where the workspace token is bounded by em dash / slash / whitespace.
+ * We require a bounded match so that basename "foo" does not match window "foo-bar".
+ */
+export function windowMatchesWorktree(windowTitle: string, worktreeBasename: string): boolean {
+	if (!worktreeBasename || !windowTitle) return false;
+	const esc = worktreeBasename.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	const re = new RegExp(`(?:^|[\\s\\u2014/])${esc}(?:[\\s\\u2014/]|$)`);
+	return re.test(windowTitle);
+}
+
+async function resolveWindowTitles(worktreeBasename: string): Promise<string[]> {
+	const titles = await listEditorWindows();
+	return titles.filter((t) => windowMatchesWorktree(t, worktreeBasename));
+}
+
 async function runOsascript(script: string): Promise<string> {
 	const proc = Bun.spawn(["osascript", "-e", script], {
 		stdout: "pipe",
 		stderr: "pipe",
 	});
-	const out = await new Response(proc.stdout).text();
+	const [out, err] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+	]);
 	await proc.exited;
+	if (proc.exitCode !== 0 && err.trim() && process.env.CCDOCK_DEBUG) {
+		process.stderr.write(`[osascript] ${err.trim()}\n`);
+	}
 	return out.trim();
 }
 
@@ -114,33 +138,40 @@ result;
 	}
 }
 
+function escapeAppleScriptString(s: string): string {
+	return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
 /**
  * Move and resize a VS Code window to fill the area right of the sidebar.
  * The VS Code window is brought to the current space and positioned
  * adjacent to the sidebar terminal.
+ *
+ * `worktreeBasename` is used to resolve a full window title via strict matching.
  */
 export async function positionEditorWindow(
-	windowTitle: string,
+	worktreeBasename: string,
 	sidebarBounds: WindowBounds,
 ): Promise<boolean> {
-	// Calculate editor position: right of sidebar, same height
+	const matches = await resolveWindowTitles(worktreeBasename);
+	const fullTitle = matches[0];
+	if (!fullTitle) return false;
+
 	const editorX = sidebarBounds.x + sidebarBounds.width + 4; // 4px gap
 	const editorY = sidebarBounds.y;
-	// Editor width: fill remaining space on the screen containing the sidebar
 	const screenRight = await getScreenRightEdge(sidebarBounds);
 	const editorWidth = screenRight - editorX;
 	const editorHeight = sidebarBounds.height;
 
 	try {
-		// Escape single quotes in title for AppleScript
-		const escapedTitle = windowTitle.replace(/'/g, "'\"'\"'");
+		const escapedTitle = escapeAppleScriptString(fullTitle);
 
 		await runOsascript(`
 tell application "System Events"
 	tell process "Code"
 		set targetWindow to missing value
 		repeat with w in every window
-			if name of w contains "${escapedTitle}" then
+			if name of w is "${escapedTitle}" then
 				set targetWindow to w
 				exit repeat
 			end if
@@ -159,36 +190,34 @@ end tell
 }
 
 /**
- * Check if a VS Code window with the given title exists.
+ * Check if a VS Code window matching the worktree basename exists.
  */
-export async function editorWindowExists(windowTitle: string): Promise<boolean> {
-	const windows = await listEditorWindows();
-	return windows.some((w) => w.includes(windowTitle));
+export async function editorWindowExists(worktreeBasename: string): Promise<boolean> {
+	const matches = await resolveWindowTitles(worktreeBasename);
+	return matches.length > 0;
 }
 
 /**
  * Bring a VS Code window to front and position it next to the sidebar.
- * Returns false if the window doesn't exist.
+ * Returns false if no matching window exists.
  */
-export async function focusAndPositionEditor(windowTitle: string): Promise<boolean> {
-	// First check if the window actually exists
-	if (!(await editorWindowExists(windowTitle))) {
-		return false;
-	}
+export async function focusAndPositionEditor(worktreeBasename: string): Promise<boolean> {
+	const matches = await resolveWindowTitles(worktreeBasename);
+	const fullTitle = matches[0];
+	if (!fullTitle) return false;
 
 	const sidebar = await getSidebarBounds();
 	if (!sidebar) return false;
 
 	try {
-		const escapedTitle = windowTitle.replace(/'/g, "'\"'\"'");
+		const escapedTitle = escapeAppleScriptString(fullTitle);
 
-		// Activate VS Code and raise the specific window
 		await runOsascript(`
 tell application "System Events"
 	tell process "Code"
 		set frontmost to true
 		repeat with w in every window
-			if name of w contains "${escapedTitle}" then
+			if name of w is "${escapedTitle}" then
 				perform action "AXRaise" of w
 				exit repeat
 			end if
@@ -197,8 +226,7 @@ tell application "System Events"
 end tell
 `);
 
-		// Position it next to sidebar
-		await positionEditorWindow(windowTitle, sidebar);
+		await positionEditorWindow(worktreeBasename, sidebar);
 		return true;
 	} catch {
 		return false;
@@ -285,19 +313,22 @@ tell application "Ghostty" to activate
 }
 
 /**
- * Close a specific VS Code window by title match.
- * Raises the window then sends Cmd+W to close it.
+ * Close a specific VS Code window matching the worktree basename.
+ * Raises the window then sends Cmd+Shift+W to close it.
  */
-export async function closeEditorWindow(windowTitle: string): Promise<void> {
+export async function closeEditorWindow(worktreeBasename: string): Promise<void> {
 	if (!(await isEditorRunning())) return;
+	const matches = await resolveWindowTitles(worktreeBasename);
+	const fullTitle = matches[0];
+	if (!fullTitle) return;
 	try {
-		const escapedTitle = windowTitle.replace(/'/g, "'\"'\"'");
+		const escapedTitle = escapeAppleScriptString(fullTitle);
 		await runOsascript(`
 tell application "System Events"
 	tell process "Code"
 		set frontmost to true
 		repeat with w in every window
-			if name of w contains "${escapedTitle}" then
+			if name of w is "${escapedTitle}" then
 				perform action "AXRaise" of w
 				delay 0.2
 				keystroke "w" using {command down, shift down}
@@ -337,13 +368,26 @@ end tell
 
 /**
  * Reposition managed VS Code windows to fill the area right of the sidebar.
- * Only windows whose title contains one of the managed titles are repositioned.
- * Called when the sidebar terminal is resized.
+ * Matching uses strict bounded matching (see windowMatchesWorktree) on the full
+ * list of window titles, and only matched windows are repositioned.
  */
-export async function repositionAllEditors(managedTitles: string[]): Promise<void> {
-	if (managedTitles.length === 0) return;
+export async function repositionAllEditors(managedBasenames: string[]): Promise<void> {
+	if (managedBasenames.length === 0) return;
 	const [running, sidebar] = await Promise.all([isEditorRunning(), getSidebarBounds()]);
 	if (!running || !sidebar) return;
+
+	// Resolve basenames -> full window titles via JS-side strict matching
+	const allTitles = await listEditorWindows();
+	const matchedTitles = new Set<string>();
+	for (const title of allTitles) {
+		for (const basename of managedBasenames) {
+			if (windowMatchesWorktree(title, basename)) {
+				matchedTitles.add(title);
+				break;
+			}
+		}
+	}
+	if (matchedTitles.size === 0) return;
 
 	try {
 		const editorX = sidebar.x + sidebar.width + 4;
@@ -352,8 +396,8 @@ export async function repositionAllEditors(managedTitles: string[]): Promise<voi
 		const editorWidth = screenRight - editorX;
 		const editorHeight = sidebar.height;
 
-		const titlesAppleScript = managedTitles
-			.map((t) => `"${t.replace(/"/g, '\\"')}"`)
+		const titlesAppleScript = Array.from(matchedTitles)
+			.map((t) => `"${escapeAppleScriptString(t)}"`)
 			.join(", ");
 
 		await runOsascript(`
@@ -364,7 +408,7 @@ tell application "System Events"
 			set wName to name of w
 			set isManaged to false
 			repeat with t in managedTitles
-				if wName contains t then
+				if wName is (t as text) then
 					set isManaged to true
 					exit repeat
 				end if

--- a/src/worktree/manager.ts
+++ b/src/worktree/manager.ts
@@ -1,7 +1,31 @@
 import { existsSync } from "node:fs";
 import type { WorktreeEntry } from "../types.ts";
 
-export async function createWorktree(repoPath: string, branchName: string): Promise<string> {
+export interface CreateWorktreeOptions {
+	/** Run `git fetch origin <base>` before creating the worktree. */
+	fetch?: boolean;
+	/** Base branch to fetch (e.g. "main"). Only used when fetch is true. */
+	base?: string;
+}
+
+async function fetchOrigin(repoPath: string, base: string): Promise<void> {
+	const proc = Bun.spawn(["git", "-C", repoPath, "fetch", "origin", base], {
+		stdout: "ignore",
+		stderr: "pipe",
+	});
+	await proc.exited;
+	// Failures are non-fatal: creation continues with whatever refs are local.
+}
+
+export async function createWorktree(
+	repoPath: string,
+	branchName: string,
+	opts: CreateWorktreeOptions = {},
+): Promise<string> {
+	if (opts.fetch && opts.base) {
+		await fetchOrigin(repoPath, opts.base);
+	}
+
 	const proc = Bun.spawn(["git", "wt", branchName], {
 		cwd: repoPath,
 		stdout: "pipe",
@@ -42,6 +66,78 @@ export async function createWorktree(repoPath: string, branchName: string): Prom
 	}
 
 	throw new Error(`Could not determine worktree path from git wt output:\n${output}`);
+}
+
+/**
+ * Create a worktree tracking a remote branch.
+ * Uses `git wt <local> <remote>` first; if the installed git-wt doesn't accept
+ * a base argument, falls back to `git worktree add -b <local> <path> <remote>`.
+ */
+export async function createWorktreeFromRemote(
+	repoPath: string,
+	localBranch: string,
+	remoteRef: string,
+): Promise<string> {
+	const proc = Bun.spawn(["git", "wt", localBranch, remoteRef], {
+		cwd: repoPath,
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [stdout, stderr] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+	]);
+	const code = await proc.exited;
+
+	if (code === 0) {
+		const output = stdout.trim();
+		for (const line of [...output.split("\n")].reverse()) {
+			const trimmed = line.trim();
+			if (trimmed.startsWith("/")) return trimmed;
+		}
+		// Fallback: find by branch name
+		const found = await findWorktreePathByBranch(repoPath, localBranch);
+		if (found) return found;
+		throw new Error(`Could not determine worktree path from git wt output:\n${output}`);
+	}
+
+	// git wt failed — fall back to native git worktree add
+	const parentDir = repoPath.replace(/\/[^/]+$/, "");
+	const repoName = repoPath.split("/").pop() ?? "worktree";
+	const safeBranch = localBranch.replace(/\//g, "-");
+	const targetPath = `${parentDir}/${repoName}--${safeBranch}`;
+
+	const addProc = Bun.spawn(
+		["git", "-C", repoPath, "worktree", "add", "-b", localBranch, targetPath, remoteRef],
+		{ stdout: "pipe", stderr: "pipe" },
+	);
+	const addStderr = await new Response(addProc.stderr).text();
+	await addProc.exited;
+	if (addProc.exitCode !== 0) {
+		throw new Error(addStderr.trim() || stderr.trim() || "worktree add failed");
+	}
+	return targetPath;
+}
+
+async function findWorktreePathByBranch(
+	repoPath: string,
+	branchName: string,
+): Promise<string | null> {
+	const listProc = Bun.spawn(["git", "-C", repoPath, "worktree", "list", "--porcelain"], {
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const listOutput = await new Response(listProc.stdout).text();
+	await listProc.exited;
+	let currentPath = "";
+	for (const line of listOutput.split("\n")) {
+		if (line.startsWith("worktree ")) currentPath = line.slice(9);
+		else if (line.startsWith("branch ")) {
+			const branch = line.slice(7).replace("refs/heads/", "");
+			if (branch === branchName) return currentPath;
+		}
+	}
+	return null;
 }
 
 export async function removeWorktree(worktreePath: string): Promise<void> {

--- a/src/worktree/remote.ts
+++ b/src/worktree/remote.ts
@@ -1,0 +1,34 @@
+/**
+ * List remote branches on `origin` from the local cache.
+ * Intentionally does NOT run `git fetch` because TUI is in raw mode and
+ * cannot surface prompts like ssh passphrase entry. Users should refresh
+ * their refs outside ccdock (e.g. `git fetch` in a shell) before creating
+ * a worktree if they need the latest branches.
+ */
+export async function listRemoteBranches(repoPath: string): Promise<string[]> {
+	const listProc = Bun.spawn(
+		["git", "-C", repoPath, "for-each-ref", "--format=%(refname:short)", "refs/remotes/origin/"],
+		{ stdout: "pipe", stderr: "ignore" },
+	);
+	const out = await new Response(listProc.stdout).text();
+	await listProc.exited;
+
+	return parseRemoteBranches(out);
+}
+
+/**
+ * Pure parser over `git for-each-ref` output: keeps only `origin/<branch>`
+ * refs, dropping `origin/HEAD` (which git may short-form to bare `origin`).
+ */
+export function parseRemoteBranches(output: string): string[] {
+	return output
+		.split("\n")
+		.map((l) => l.trim())
+		.filter(
+			(l) =>
+				l.startsWith("origin/") &&
+				l.length > "origin/".length &&
+				l !== "origin/HEAD" &&
+				!l.includes("->"),
+		);
+}

--- a/test/hook.test.ts
+++ b/test/hook.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentState } from "../src/types.ts";
+
+let stateRoot: string;
+const MAIN = join(import.meta.dir, "..", "src", "main.ts");
+
+beforeEach(() => {
+	stateRoot = mkdtempSync(join(tmpdir(), "ccdock-hook-"));
+});
+
+afterEach(() => {
+	rmSync(stateRoot, { recursive: true, force: true });
+});
+
+async function runHook(event: string, payload: Record<string, unknown>): Promise<void> {
+	const proc = Bun.spawn(["bun", "run", MAIN, "hook", "claude-code", event], {
+		stdin: "pipe",
+		stdout: "pipe",
+		stderr: "pipe",
+		env: { ...process.env, XDG_STATE_HOME: stateRoot },
+	});
+	proc.stdin.write(JSON.stringify(payload));
+	await proc.stdin.end();
+	await proc.exited;
+}
+
+function agentsDir(): string {
+	return join(stateRoot, "ccdock", "agents");
+}
+
+function readOnlyAgent(): AgentState {
+	const files = readdirSync(agentsDir()).filter((f) => f.endsWith(".json"));
+	expect(files.length).toBe(1);
+	const raw = readFileSync(join(agentsDir(), files[0]!), "utf-8");
+	return JSON.parse(raw) as AgentState;
+}
+
+describe("ccdock hook", () => {
+	test("PreToolUse writes a running agent state", async () => {
+		await runHook("PreToolUse", {
+			session_id: "sess-abc",
+			cwd: "/tmp/workspace/repo",
+			tool_name: "Bash",
+			tool_input: { command: "ls" },
+		});
+		const state = readOnlyAgent();
+		expect(state.status).toBe("running");
+		expect(state.toolName).toBe("Bash");
+		expect(state.toolDetail).toBe("ls");
+	});
+
+	test("Stop writes stopped (not idle)", async () => {
+		await runHook("Stop", {
+			session_id: "sess-abc",
+			cwd: "/tmp/workspace/repo",
+			stop_reason: "completed",
+		});
+		const state = readOnlyAgent();
+		expect(state.status).toBe("stopped");
+	});
+
+	test("PermissionRequest writes waiting", async () => {
+		await runHook("PermissionRequest", {
+			session_id: "sess-abc",
+			cwd: "/tmp/workspace/repo",
+		});
+		const state = readOnlyAgent();
+		expect(state.status).toBe("waiting");
+	});
+
+	test("SessionEnd removes the agent file", async () => {
+		await runHook("PreToolUse", {
+			session_id: "sess-abc",
+			cwd: "/tmp/workspace/repo",
+			tool_name: "Read",
+			tool_input: { file_path: "/tmp/x" },
+		});
+		expect(readdirSync(agentsDir()).length).toBe(1);
+
+		await runHook("SessionEnd", {
+			session_id: "sess-abc",
+			cwd: "/tmp/workspace/repo",
+		});
+		expect(readdirSync(agentsDir()).length).toBe(0);
+	});
+
+	test("Notification preserves previous state and only bumps updatedAt", async () => {
+		await runHook("PreToolUse", {
+			session_id: "sess-abc",
+			cwd: "/tmp/workspace/repo",
+			tool_name: "Bash",
+			tool_input: { command: "echo hi" },
+		});
+		const before = readOnlyAgent();
+
+		// brief wait to ensure updatedAt differs
+		await Bun.sleep(20);
+
+		await runHook("Notification", {
+			session_id: "sess-abc",
+			cwd: "/tmp/workspace/repo",
+		});
+		const after = readOnlyAgent();
+
+		expect(after.status).toBe(before.status);
+		expect(after.toolName).toBe(before.toolName);
+		expect(after.toolDetail).toBe(before.toolDetail);
+		expect(after.updatedAt).toBeGreaterThan(before.updatedAt);
+	});
+
+	test("Stop clears toolName/toolDetail", async () => {
+		await runHook("PreToolUse", {
+			session_id: "sess-abc",
+			cwd: "/tmp/workspace/repo",
+			tool_name: "Bash",
+			tool_input: { command: "something" },
+		});
+		await runHook("Stop", {
+			session_id: "sess-abc",
+			cwd: "/tmp/workspace/repo",
+		});
+		const state = readOnlyAgent();
+		expect(state.status).toBe("stopped");
+		expect(state.toolName).toBe("");
+	});
+
+	test("missing session_id does nothing (no file created)", async () => {
+		await runHook("PreToolUse", { cwd: "/tmp/workspace/repo" });
+		if (existsSync(agentsDir())) {
+			expect(readdirSync(agentsDir()).length).toBe(0);
+		}
+	});
+});

--- a/test/input.test.ts
+++ b/test/input.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeFullwidth, parseKey, parseKeyWizard } from "../src/tui/input.ts";
+
+describe("normalizeFullwidth", () => {
+	test("maps fullwidth ASCII letters to halfwidth", () => {
+		expect(normalizeFullwidth("\uFF4E")).toBe("n");
+		expect(normalizeFullwidth("\uFF24")).toBe("D");
+		expect(normalizeFullwidth("\uFF10\uFF11\uFF12")).toBe("012");
+	});
+
+	test("maps fullwidth space to regular space", () => {
+		expect(normalizeFullwidth("\u3000")).toBe(" ");
+	});
+
+	test("passes through halfwidth ASCII unchanged", () => {
+		expect(normalizeFullwidth("nqcrlx")).toBe("nqcrlx");
+	});
+
+	test("leaves non-ASCII runes (hiragana, kanji) alone", () => {
+		expect(normalizeFullwidth("\u3042\u4e00")).toBe("\u3042\u4e00");
+	});
+});
+
+describe("parseKey (sidebar)", () => {
+	test("halfwidth shortcuts fire their actions", () => {
+		expect(parseKey(Buffer.from("n"))).toEqual({ type: "new" });
+		expect(parseKey(Buffer.from("d"))).toEqual({ type: "delete" });
+		expect(parseKey(Buffer.from("q"))).toEqual({ type: "quit" });
+		expect(parseKey(Buffer.from("j"))).toEqual({ type: "down" });
+		expect(parseKey(Buffer.from("k"))).toEqual({ type: "up" });
+		expect(parseKey(Buffer.from("c"))).toEqual({ type: "compact" });
+		expect(parseKey(Buffer.from("l"))).toEqual({ type: "log" });
+		expect(parseKey(Buffer.from("r"))).toEqual({ type: "realign" });
+	});
+
+	test("fullwidth shortcuts fire the same actions (IME on)", () => {
+		expect(parseKey(Buffer.from("\uFF4E"))).toEqual({ type: "new" });
+		expect(parseKey(Buffer.from("\uFF44"))).toEqual({ type: "delete" });
+		expect(parseKey(Buffer.from("\uFF51"))).toEqual({ type: "quit" });
+		expect(parseKey(Buffer.from("\uFF4A"))).toEqual({ type: "down" });
+		expect(parseKey(Buffer.from("\uFF4B"))).toEqual({ type: "up" });
+	});
+
+	test("control codes", () => {
+		expect(parseKey(Buffer.from("\r"))).toEqual({ type: "enter" });
+		expect(parseKey(Buffer.from("\t"))).toEqual({ type: "tab" });
+		expect(parseKey(Buffer.from("\x03"))).toEqual({ type: "quit" }); // Ctrl+C
+	});
+
+	test("arrow key escape sequences", () => {
+		expect(parseKey(Buffer.from("\x1b[A"))).toEqual({ type: "up" });
+		expect(parseKey(Buffer.from("\x1b[B"))).toEqual({ type: "down" });
+	});
+
+	test("SGR mouse click is parsed as mouse_click", () => {
+		expect(parseKey(Buffer.from("\x1b[<0;12;5M"))).toEqual({
+			type: "mouse_click",
+			row: 5,
+			col: 12,
+		});
+	});
+
+	test("scroll wheel becomes up/down", () => {
+		expect(parseKey(Buffer.from("\x1b[<64;1;1M"))).toEqual({ type: "up" });
+		expect(parseKey(Buffer.from("\x1b[<65;1;1M"))).toEqual({ type: "down" });
+	});
+
+	test("unknown input yields unknown", () => {
+		expect(parseKey(Buffer.from("z"))).toEqual({ type: "unknown" });
+	});
+});
+
+describe("parseKeyWizard", () => {
+	test("fullwidth char input is normalized to halfwidth", () => {
+		expect(parseKeyWizard(Buffer.from("\uFF41"))).toEqual({ type: "char", char: "a" });
+	});
+
+	test("halfwidth printable chars pass through", () => {
+		expect(parseKeyWizard(Buffer.from("a"))).toEqual({ type: "char", char: "a" });
+	});
+
+	test("escape and backspace", () => {
+		expect(parseKeyWizard(Buffer.from("\x1b"))).toEqual({ type: "escape" });
+		expect(parseKeyWizard(Buffer.from("\x03"))).toEqual({ type: "escape" });
+		expect(parseKeyWizard(Buffer.from("\x7f"))).toEqual({ type: "backspace" });
+	});
+
+	test("non-ASCII runes yield unknown (IME unconfirmed preview is out of scope)", () => {
+		expect(parseKeyWizard(Buffer.from("\u3042"))).toEqual({ type: "unknown" });
+	});
+});

--- a/test/remote.test.ts
+++ b/test/remote.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { parseRemoteBranches } from "../src/worktree/remote.ts";
+
+describe("parseRemoteBranches", () => {
+	test("drops bare 'origin' (short-form of origin/HEAD)", () => {
+		const out = "origin\norigin/main\norigin/feature-x";
+		expect(parseRemoteBranches(out)).toEqual(["origin/main", "origin/feature-x"]);
+	});
+
+	test("drops explicit origin/HEAD", () => {
+		const out = "origin/HEAD\norigin/main";
+		expect(parseRemoteBranches(out)).toEqual(["origin/main"]);
+	});
+
+	test("drops arrow-style alias lines", () => {
+		const out = "origin/HEAD -> origin/main\norigin/main";
+		expect(parseRemoteBranches(out)).toEqual(["origin/main"]);
+	});
+
+	test("ignores non-origin refs defensively", () => {
+		const out = "upstream/main\norigin/dev";
+		expect(parseRemoteBranches(out)).toEqual(["origin/dev"]);
+	});
+
+	test("trims whitespace and drops empty lines", () => {
+		const out = "  origin/main  \n\n  origin/feature  \n";
+		expect(parseRemoteBranches(out)).toEqual(["origin/main", "origin/feature"]);
+	});
+
+	test("empty input returns empty array", () => {
+		expect(parseRemoteBranches("")).toEqual([]);
+	});
+});

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentState, WorkspaceSession } from "../src/types.ts";
+
+// state.ts resolves its directories lazily from XDG_STATE_HOME / HOME each call.
+// We redirect them to a temp dir for each test.
+
+let stateRoot: string;
+let originalXdg: string | undefined;
+
+beforeEach(() => {
+	stateRoot = mkdtempSync(join(tmpdir(), "ccdock-state-"));
+	originalXdg = process.env.XDG_STATE_HOME;
+	process.env.XDG_STATE_HOME = stateRoot;
+});
+
+afterEach(() => {
+	if (originalXdg === undefined) delete process.env.XDG_STATE_HOME;
+	else process.env.XDG_STATE_HOME = originalXdg;
+	rmSync(stateRoot, { recursive: true, force: true });
+});
+
+function writeAgent(filename: string, state: AgentState): string {
+	const dir = join(stateRoot, "ccdock", "agents");
+	mkdirSync(dir, { recursive: true });
+	const p = join(dir, filename);
+	writeFileSync(p, JSON.stringify(state));
+	return p;
+}
+
+function writeSession(session: WorkspaceSession): void {
+	const dir = join(stateRoot, "ccdock", "sessions");
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(join(dir, `${session.id}.json`), JSON.stringify(session));
+}
+
+function buildSession(overrides: Partial<WorkspaceSession> = {}): WorkspaceSession {
+	return {
+		id: "sess1",
+		sessionName: "repo:main",
+		worktreePath: "/tmp/repo",
+		branch: "main",
+		repoName: "repo",
+		agents: [],
+		editorState: "open",
+		createdAt: 0,
+		lastActiveAt: 0,
+		...overrides,
+	};
+}
+
+function buildAgent(overrides: Partial<AgentState> = {}): AgentState {
+	return {
+		sessionId: "sess1",
+		agentType: "claude-code",
+		status: "idle",
+		prompt: "",
+		toolName: "",
+		toolDetail: "",
+		cwd: "/tmp/repo",
+		updatedAt: Date.now(),
+		...overrides,
+	};
+}
+
+describe("cleanStaleAgents", () => {
+	test("keeps stopped agent regardless of age", async () => {
+		const { cleanStaleAgents } = await import(`../src/workspace/state.ts?t=${Date.now()}`);
+		writeSession(buildSession());
+		const p = writeAgent(
+			"a.json",
+			buildAgent({
+				status: "stopped",
+				updatedAt: Date.now() - 999 * 60 * 60 * 1000, // very old
+			}),
+		);
+		cleanStaleAgents();
+		expect(existsSync(p)).toBe(true);
+	});
+
+	test("keeps idle agent regardless of age", async () => {
+		const { cleanStaleAgents } = await import(`../src/workspace/state.ts?t=${Date.now()}`);
+		writeSession(buildSession());
+		const p = writeAgent(
+			"b.json",
+			buildAgent({ status: "idle", updatedAt: Date.now() - 999 * 60 * 60 * 1000 }),
+		);
+		cleanStaleAgents();
+		expect(existsSync(p)).toBe(true);
+	});
+
+	test("removes transient (running) agent older than 30 minutes", async () => {
+		const { cleanStaleAgents } = await import(`../src/workspace/state.ts?t=${Date.now()}`);
+		writeSession(buildSession());
+		const p = writeAgent(
+			"c.json",
+			buildAgent({ status: "running", updatedAt: Date.now() - 31 * 60 * 1000 }),
+		);
+		cleanStaleAgents();
+		expect(existsSync(p)).toBe(false);
+	});
+
+	test("keeps running agent younger than 30 minutes", async () => {
+		const { cleanStaleAgents } = await import(`../src/workspace/state.ts?t=${Date.now()}`);
+		writeSession(buildSession());
+		const p = writeAgent(
+			"d.json",
+			buildAgent({ status: "running", updatedAt: Date.now() - 60 * 1000 }),
+		);
+		cleanStaleAgents();
+		expect(existsSync(p)).toBe(true);
+	});
+
+	test("removes orphan agent (no matching session)", async () => {
+		const { cleanStaleAgents } = await import(`../src/workspace/state.ts?t=${Date.now()}`);
+		// No session written — agent has no home
+		const p = writeAgent(
+			"orphan.json",
+			buildAgent({
+				status: "stopped",
+				sessionId: "",
+				cwd: "/some/unknown/path",
+				updatedAt: Date.now(),
+			}),
+		);
+		cleanStaleAgents();
+		expect(existsSync(p)).toBe(false);
+	});
+
+	test("keeps agent whose cwd is a prefix of a known session worktreePath", async () => {
+		const { cleanStaleAgents } = await import(`../src/workspace/state.ts?t=${Date.now()}`);
+		writeSession(buildSession({ worktreePath: "/tmp/repo" }));
+		const p = writeAgent(
+			"e.json",
+			buildAgent({
+				sessionId: "", // no direct match
+				cwd: "/tmp/repo/subdir",
+				status: "idle",
+				updatedAt: Date.now(),
+			}),
+		);
+		cleanStaleAgents();
+		expect(existsSync(p)).toBe(true);
+	});
+});

--- a/test/window.test.ts
+++ b/test/window.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { windowMatchesWorktree } from "../src/workspace/window.ts";
+
+describe("windowMatchesWorktree", () => {
+	test("matches basename surrounded by em dash (VS Code workspace title)", () => {
+		expect(windowMatchesWorktree("myfile.ts \u2014 foo \u2014 Visual Studio Code", "foo")).toBe(
+			true,
+		);
+		expect(windowMatchesWorktree("foo \u2014 Visual Studio Code", "foo")).toBe(true);
+	});
+
+	test("matches basename with hyphen inside", () => {
+		expect(
+			windowMatchesWorktree("src/file.ts \u2014 foo-bar \u2014 Visual Studio Code", "foo-bar"),
+		).toBe(true);
+	});
+
+	test("does NOT match when basename is a substring of a different token", () => {
+		// "foo" must not match a window for "foo-bar"
+		expect(
+			windowMatchesWorktree("src/file.ts \u2014 foo-bar \u2014 Visual Studio Code", "foo"),
+		).toBe(false);
+		// "bar" must not match a window for "foo-bar"
+		expect(
+			windowMatchesWorktree("src/file.ts \u2014 foo-bar \u2014 Visual Studio Code", "bar"),
+		).toBe(false);
+	});
+
+	test("matches bounded by whitespace or slash", () => {
+		expect(windowMatchesWorktree("path/to/foo/index.ts \u2014 repo", "foo")).toBe(true);
+		expect(windowMatchesWorktree("foo", "foo")).toBe(true);
+	});
+
+	test("empty inputs return false", () => {
+		expect(windowMatchesWorktree("", "foo")).toBe(false);
+		expect(windowMatchesWorktree("anything", "")).toBe(false);
+	});
+
+	test("escapes regex metacharacters in basename", () => {
+		expect(windowMatchesWorktree("foo.bar \u2014 repo", "foo.bar")).toBe(true);
+		// Not a regex wildcard: "foo.bar" should not match "fooxbar"
+		expect(windowMatchesWorktree("fooxbar \u2014 repo", "foo.bar")).toBe(false);
+	});
+});

--- a/test/worktree.test.ts
+++ b/test/worktree.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { listWorktrees, removeWorktree } from "../src/worktree/manager.ts";
+
+// These tests only cover operations that don't require git-wt.
+// createWorktree / createWorktreeFromRemote call out to `git wt` which is an
+// external dependency and is exercised via manual E2E.
+
+let root: string;
+let repo: string;
+
+async function run(cmd: string[], cwd?: string): Promise<void> {
+	const proc = Bun.spawn(cmd, {
+		cwd,
+		stdout: "ignore",
+		stderr: "pipe",
+	});
+	const err = await new Response(proc.stderr).text();
+	await proc.exited;
+	if (proc.exitCode !== 0) {
+		throw new Error(`${cmd.join(" ")} failed: ${err}`);
+	}
+}
+
+beforeEach(async () => {
+	// realpath to match what git returns (macOS tmpdir is a symlink to /private/var/...)
+	root = realpathSync(mkdtempSync(join(tmpdir(), "ccdock-wt-")));
+	repo = join(root, "repo");
+	await run(["git", "init", "-q", "-b", "main", repo]);
+	await run(["git", "-C", repo, "config", "user.email", "test@example.com"]);
+	await run(["git", "-C", repo, "config", "user.name", "Test"]);
+	writeFileSync(join(repo, "README.md"), "hello\n");
+	await run(["git", "-C", repo, "add", "."]);
+	await run(["git", "-C", repo, "commit", "-q", "-m", "init"]);
+});
+
+afterEach(() => {
+	rmSync(root, { recursive: true, force: true });
+});
+
+describe("listWorktrees", () => {
+	test("returns the main worktree of a fresh repo", async () => {
+		const worktrees = await listWorktrees(repo);
+		expect(worktrees.length).toBe(1);
+		expect(worktrees[0]?.branch).toBe("main");
+		expect(worktrees[0]?.path).toBe(repo);
+	});
+
+	test("returns added worktrees", async () => {
+		const wtPath = join(root, "feature");
+		await run(["git", "-C", repo, "worktree", "add", "-b", "feature", wtPath]);
+		const worktrees = await listWorktrees(repo);
+		const branches = worktrees.map((w) => w.branch).sort();
+		expect(branches).toEqual(["feature", "main"]);
+	});
+});
+
+describe("removeWorktree", () => {
+	test("removes an existing linked worktree", async () => {
+		const wtPath = join(root, "feature");
+		await run(["git", "-C", repo, "worktree", "add", "-b", "feature", wtPath]);
+		expect(existsSync(wtPath)).toBe(true);
+
+		await removeWorktree(wtPath);
+		expect(existsSync(wtPath)).toBe(false);
+	});
+
+	test("is a no-op when path does not exist", async () => {
+		await removeWorktree(join(root, "never-created"));
+		// reached here without throwing
+		expect(true).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

Closes #1, #2, #3, #4, #5, #6.

- **#1** idle/stopped agent を永続、transient (running/waiting) のみ 30 分で stale 化、孤児 agent も掃除
- **#2** `stopped` ステータスを新設 (Stop hook)。`idle` は「起動したが未着手」用に予約、teal `●` / gray `○` で視覚的に区別
- **#3** 削除中はスピナー + `Deleting session...` を表示し、その session への入力を一時無効化
- **#4** ウインドウ↔カードのマッチングを em dash / ハイフン / 空白 / スラッシュ / 文字列端で境界付けした正規表現に変更。AppleScript も JS 側で完全タイトル解決してから渡す
- **#5** wizard に `Create worktree from remote branch` モードを追加 (ローカル `origin/*` キャッシュのみ、raw-mode TUI で ssh パスフレーズ入力ができないため fetch は行わない)。`git wt` が base 引数非対応の場合は `git worktree add` にフォールバック
- **#6** wizard に `fetch-choice` ステップを追加、作成前に `git fetch origin <default>` するか選択可能
- **Fullwidth → halfwidth 正規化** IME ON 時の全角 `ｎ`/`ｊ`/`ｋ`/`ｄ`/`ｃ`/`ｌ`/`ｑ`/`ｒ`/`ｘ` も半角と同じショートカットとして動作
- **realign バグ修正** AppleScript の `repeat` ループ内で `is t` 比較がアイテム参照のため失敗していたのを `is (t as text)` に変更
- **リモートブランチ一覧の origin 単独エントリ修正** `git for-each-ref` が `origin/HEAD` を短縮形 `origin` で出すのを除外

## Tests

44 tests added across 6 files:

| File | Coverage |
| --- | --- |
| `test/window.test.ts` | `windowMatchesWorktree` — 境界マッチ (#4) |
| `test/input.test.ts` | `parseKey` / `parseKeyWizard` / `normalizeFullwidth` — 全角対応 |
| `test/remote.test.ts` | `parseRemoteBranches` — `origin/HEAD` 除外 (#5) |
| `test/state.test.ts` | `cleanStaleAgents` — idle/stopped 保持、孤児削除 (#1) |
| `test/hook.test.ts` | `ccdock hook` E2E (サブプロセス経由) — 状態遷移 (#2) |
| `test/worktree.test.ts` | `listWorktrees` / `removeWorktree` — 一時 git repo 使用 |

```sh
bun test  # → 44 pass / 0 fail
```

## Test plan

- [x] `bun run typecheck` 通過
- [x] `bun run format` 差分なし
- [x] `bun test` 全 44 テスト pass
- [x] 手動: `bun link` でローカルビルドを `ccdock` コマンドに接続し、以下を確認
  - [x] `r` で realign が動く
  - [x] IME ON の全角入力でもショートカットが反応
  - [x] select-remote-branch に `origin` 単独エントリが出ない
- [ ] 手動 (未確認): 削除スピナー、fetch-choice ステップ、stopped ステータスの表示 — マージ前に実機で確認してください

🤖 Generated with [Claude Code](https://claude.com/claude-code)