### PR TITLE
ci: add release workflow for npm publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+name: release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump type"
+        type: choice
+        required: true
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
+      dry_run:
+        description: "Dry run (skip npm publish and git push)"
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      BUMP: ${{ inputs.bump }}
+      DRY_RUN: ${{ inputs.dry_run }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Run tests
+        run: bun test
+
+      - name: Bump version
+        id: bump
+        run: |
+          new_version=$(npx -y npm@latest version "$BUMP" --no-git-tag-version)
+          echo "version=${new_version}" >> "$GITHUB_OUTPUT"
+          echo "Bumped to ${new_version}"
+
+      - name: Commit and tag
+        env:
+          VERSION: ${{ steps.bump.outputs.version }}
+        run: |
+          git add package.json
+          git commit -m "chore: release ${VERSION}"
+          git tag "${VERSION}"
+
+      - name: Push to main
+        if: ${{ env.DRY_RUN != 'true' }}
+        env:
+          VERSION: ${{ steps.bump.outputs.version }}
+        run: |
+          git push origin HEAD:main
+          git push origin "${VERSION}"
+
+      - name: Publish to npm (trusted publishing + provenance)
+        if: ${{ env.DRY_RUN != 'true' }}
+        run: npx -y npm@latest publish --provenance --access public
+
+      - name: Dry-run publish
+        if: ${{ env.DRY_RUN == 'true' }}
+        run: npx -y npm@latest publish --dry-run --access public


### PR DESCRIPTION
## Summary
- npm publishを行うリリースワークフローを追加
- `workflow_dispatch`で手動実行、patch/minor/majorのバージョンバンプを選択可能
- dry-runオプション付きで安全にテスト可能
- npm trusted publishing (provenance) を使用

## Test plan
- [ ] GitHub Actionsの`Run workflow`からdry-runで実行し、ワークフローが正常に動作することを確認
- [ ] dry-runなしで実際にnpm publishが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)