### PR TITLE
feat: add Codex CLI agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 # ccdock
 
 </div>
-A TUI sidebar to orchestrate VS Code windows and track Claude Code agents.
+A TUI sidebar to orchestrate VS Code windows and track Claude Code / Codex agents.
 
 <div align="center">
 <video src="https://github.com/user-attachments/assets/fed113ef-be36-4cea-9b6b-2bc9f3db1448" width="300" autoplay loop muted playsinline></video>
@@ -84,6 +84,47 @@ Add to `~/.claude/settings.json` to enable agent status monitoring:
   }
 }
 ```
+
+### 3. Set up Codex hooks (optional)
+
+If you use [OpenAI Codex CLI](https://github.com/openai/codex), you can forward its lifecycle hooks to ccdock too. Tested with `codex-cli 0.123.0`.
+
+1. Enable the under-development `codex_hooks` feature in `~/.codex/config.toml`:
+
+   ```toml
+   [features]
+   codex_hooks = true
+   ```
+
+2. Create `~/.codex/hooks.json` (Codex 0.123.0 only reads hooks from this file — inline TOML hooks in `config.toml` are not wired up yet):
+
+   ```json
+   {
+     "hooks": {
+       "PreToolUse": [
+         { "matcher": "", "hooks": [{ "type": "command", "command": "ccdock hook codex PreToolUse", "timeout": 30 }] }
+       ],
+       "PostToolUse": [
+         { "matcher": "", "hooks": [{ "type": "command", "command": "ccdock hook codex PostToolUse", "timeout": 30 }] }
+       ],
+       "PermissionRequest": [
+         { "matcher": "", "hooks": [{ "type": "command", "command": "ccdock hook codex PermissionRequest", "timeout": 30 }] }
+       ],
+       "Stop": [
+         { "matcher": "", "hooks": [{ "type": "command", "command": "ccdock hook codex Stop", "timeout": 30 }] }
+       ]
+     }
+   }
+   ```
+
+3. Restart Codex so it picks up the new configuration.
+
+**Known limitations (upstream Codex)**
+
+- Only `Bash`-style shell tools (`local_shell` / `shell` / `exec_command`) fire hooks reliably today. `apply_patch`, file writes, and MCP tool invocations currently do not emit `PreToolUse`/`PostToolUse` ([openai/codex#16732](https://github.com/openai/codex/issues/16732), [#17794](https://github.com/openai/codex/issues/17794)).
+- `Stop` does not fire under `codex exec` ([openai/codex#18607](https://github.com/openai/codex/issues/18607)); interactive sessions are fine.
+- Hooks are disabled on Windows.
+- Codex does not emit `SessionEnd`. Agents in the `stopped` state (after the `Stop` hook) are preserved indefinitely so completed sessions stay visible; entries are removed when the matching session is deleted or when the agent's `cwd` no longer maps to a known session.
 
 ## Usage
 

--- a/src/agent/hook.ts
+++ b/src/agent/hook.ts
@@ -10,7 +10,18 @@ function sanitize(path: string): string {
 	return path.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 100);
 }
 
-function extractToolDetail(toolName: string, toolInput: Record<string, unknown>): string {
+function extractToolDetail(
+	agentType: AgentType,
+	toolName: string,
+	toolInput: Record<string, unknown>,
+): string {
+	if (agentType === "codex") {
+		return extractCodexToolDetail(toolName, toolInput);
+	}
+	return extractClaudeCodeToolDetail(toolName, toolInput);
+}
+
+function extractClaudeCodeToolDetail(toolName: string, toolInput: Record<string, unknown>): string {
 	switch (toolName) {
 		case "Bash":
 			return (toolInput.command as string) ?? "";
@@ -30,6 +41,26 @@ function extractToolDetail(toolName: string, toolInput: Record<string, unknown>)
 			return (toolInput.query as string) ?? "";
 		case "WebFetch":
 			return (toolInput.url as string) ?? "";
+		default:
+			return "";
+	}
+}
+
+function extractCodexToolDetail(toolName: string, toolInput: Record<string, unknown>): string {
+	switch (toolName) {
+		case "local_shell":
+		case "shell":
+		case "shell_command":
+		case "exec_command": {
+			const command = toolInput.command;
+			if (Array.isArray(command)) return command.join(" ");
+			if (typeof command === "string") return command;
+			return "";
+		}
+		case "apply_patch": {
+			const path = (toolInput.file_path as string) ?? (toolInput.path as string) ?? "";
+			return shortenPath(path);
+		}
 		default:
 			return "";
 	}
@@ -105,7 +136,7 @@ export async function handleHook(agentType: string, eventName: string): Promise<
 	const sessionId = findSessionByPath(cwd);
 	const rawToolName = (payload.tool_name as string) ?? "";
 	const toolInput = (payload.tool_input as Record<string, unknown>) ?? {};
-	const rawToolDetail = extractToolDetail(rawToolName, toolInput);
+	const rawToolDetail = extractToolDetail(agentType as AgentType, rawToolName, toolInput);
 
 	// Preserve previous toolName/toolDetail only for events that don't carry tool info
 	// but clear them on Stop (stopped) since the agent is no longer doing anything

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,7 +24,7 @@ HOOK USAGE:
   ccdock hook <agent-type> <event-name>
 
   Agent types: claude-code, codex
-  Events: PreToolUse, PostToolUse, Stop, session.end, Notification
+  Events: PreToolUse, PostToolUse, PermissionRequest, Stop, Notification, SessionEnd
 
 KEYBINDINGS (sidebar):
   j/k         Navigate sessions


### PR DESCRIPTION
## Summary

- `ccdock hook codex <Event>` can now receive lifecycle hooks from OpenAI's Codex CLI in the same shape as Claude Code, so a worktree running `codex` lights up in the sidebar with `running` → `stopped` transitions and the current shell command.
- `src/agent/hook.ts` dispatches `extractToolDetail` on `AgentType`: the new codex branch formats `local_shell` / `shell` / `shell_command` / `exec_command` (command line) and `apply_patch` (file path); unknown tools (MCP etc.) fall through to an empty detail.
- `src/main.ts` help line is corrected to list the real event names.
- README gets a new "Set up Codex hooks" section that matches what actually works on `codex-cli 0.123.0`:
  - Enable the `codex_hooks` feature flag and place hook definitions in `~/.codex/hooks.json` (inline TOML hooks in `config.toml` are **not** wired up in 0.123.0).
  - Upstream limitations are surfaced so users aren't surprised: only Bash-style shell tools (`local_shell`/`shell`/`exec_command`) fire reliably, `apply_patch` / file writes / MCP tools don't emit hooks today ([#16732](https://github.com/openai/codex/issues/16732), [#17794](https://github.com/openai/codex/issues/17794)), `Stop` misses under `codex exec` ([#18607](https://github.com/openai/codex/issues/18607)), Windows is disabled, and there's no `SessionEnd` (so `stopped` entries stay visible until the session is removed or the cwd no longer matches).

No new files, no new dependencies — the existing `AgentType` union, `cleanStaleAgents()` TTL, and sidebar rendering all handle codex without further changes.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run format`
- [x] `bun test` (44 passing)
- [x] Manual hook payloads for codex (`local_shell` array/string, `apply_patch`, MCP tool, `Stop`) and a Claude Code regression payload, all producing the expected `agentType` / `status` / `toolName` / `toolDetail` in `~/.local/state/ccdock/agents/*.json`.
- [x] End-to-end: with `~/.codex/hooks.json` pointing at `ccdock hook codex …` and `codex_hooks = true`, a real `codex` session writes `agentType: "codex"` entries and the sidebar shows them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)