### PR TITLE
fix: show spinner during session creation

### DIFF
--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -130,7 +130,9 @@ async function refreshSessions(state: SidebarState): Promise<void> {
 let lastRendered = "";
 
 function render(state: SidebarState): void {
-	const output = state.wizard ? renderWizard(state.wizard, state.cols) : renderSidebar(state);
+	const output = state.wizard
+		? renderWizard(state.wizard, state.cols, state.animationFrame)
+		: renderSidebar(state);
 	if (output === lastRendered) return;
 	lastRendered = output;
 	process.stdout.write(output);
@@ -224,14 +226,19 @@ async function handleWizardInput(
 						};
 					} else if (wizard.selectedIndex === 3) {
 						// Open repository root
-						await createSessionFromPath(
-							wizard.repo,
-							wizard.repo.path,
-							wizard.repo.defaultBranch,
-							config.editor,
-						);
-						state.wizard = null;
-						refreshSessions(state);
+						const repo = wizard.repo;
+						state.wizard = {
+							step: "creating",
+							repo,
+							message: "Opening repository...",
+						};
+						render(state);
+						void (async () => {
+							await createSessionFromPath(repo, repo.path, repo.defaultBranch, config.editor);
+							state.wizard = null;
+							await refreshSessions(state);
+							render(state);
+						})();
 					}
 					break;
 				case "escape":
@@ -256,9 +263,19 @@ async function handleWizardInput(
 				case "enter": {
 					const selected = wizard.worktrees[wizard.selectedIndex];
 					if (selected) {
-						await createSessionFromPath(wizard.repo, selected.path, selected.branch, config.editor);
-						state.wizard = null;
-						refreshSessions(state);
+						const repo = wizard.repo;
+						state.wizard = {
+							step: "creating",
+							repo,
+							message: "Opening worktree...",
+						};
+						render(state);
+						void (async () => {
+							await createSessionFromPath(repo, selected.path, selected.branch, config.editor);
+							state.wizard = null;
+							await refreshSessions(state);
+							render(state);
+						})();
 					}
 					break;
 				}
@@ -305,14 +322,21 @@ async function handleWizardInput(
 			switch (key.type) {
 				case "enter": {
 					if (wizard.branchName.trim()) {
-						await createSession(
-							wizard.repo,
-							wizard.branchName.trim(),
-							config.editor,
-							wizard.fetchBeforeCreate,
-						);
-						state.wizard = null;
-						refreshSessions(state);
+						const repo = wizard.repo;
+						const branch = wizard.branchName.trim();
+						const fetchBefore = wizard.fetchBeforeCreate;
+						state.wizard = {
+							step: "creating",
+							repo,
+							message: "Creating worktree...",
+						};
+						render(state);
+						void (async () => {
+							await createSession(repo, branch, config.editor, fetchBefore);
+							state.wizard = null;
+							await refreshSessions(state);
+							render(state);
+						})();
 					}
 					break;
 				}
@@ -383,14 +407,21 @@ async function handleWizardInput(
 			switch (key.type) {
 				case "enter": {
 					if (wizard.localBranch.trim()) {
-						await createSessionFromRemote(
-							wizard.repo,
-							wizard.localBranch.trim(),
-							wizard.remoteRef,
-							config.editor,
-						);
-						state.wizard = null;
-						refreshSessions(state);
+						const repo = wizard.repo;
+						const localBranch = wizard.localBranch.trim();
+						const remoteRef = wizard.remoteRef;
+						state.wizard = {
+							step: "creating",
+							repo,
+							message: "Creating worktree from remote...",
+						};
+						render(state);
+						void (async () => {
+							await createSessionFromRemote(repo, localBranch, remoteRef, config.editor);
+							state.wizard = null;
+							await refreshSessions(state);
+							render(state);
+						})();
 					}
 					break;
 				}
@@ -415,6 +446,9 @@ async function handleWizardInput(
 			}
 			break;
 		}
+		case "creating":
+			// Ignore all input while creating — operation is in progress
+			break;
 	}
 }
 

--- a/src/tui/wizard.ts
+++ b/src/tui/wizard.ts
@@ -1,6 +1,8 @@
 import type { RepoInfo, WizardState, WorktreeEntry } from "../types.ts";
 import { BOLD, BOX, CLEAR_SCREEN, COLORS, CURSOR_HOME, DIM, RESET, truncate } from "./ansi.ts";
 
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
 function renderRepoList(
 	repos: RepoInfo[],
 	selectedIndex: number,
@@ -258,7 +260,25 @@ function renderLocalBranchInput(
 	return lines;
 }
 
-export function renderWizard(wizard: WizardState, cols: number): string {
+function renderCreating(
+	repo: RepoInfo,
+	message: string,
+	cols: number,
+	animFrame: number,
+): string[] {
+	const lines: string[] = [];
+	const frame = SPINNER_FRAMES[animFrame % SPINNER_FRAMES.length]!;
+
+	lines.push(`${BOLD}${COLORS.highlight} Creating Session: ${repo.name}${RESET}`);
+	lines.push("");
+	lines.push(`  ${COLORS.highlight}${frame}${RESET} ${message}`);
+	lines.push("");
+	lines.push(`${COLORS.muted}  Please wait...${RESET}`);
+
+	return lines;
+}
+
+export function renderWizard(wizard: WizardState, cols: number, animFrame = 0): string {
 	if (!wizard) return "";
 
 	const output: string[] = [];
@@ -293,6 +313,9 @@ export function renderWizard(wizard: WizardState, cols: number): string {
 			break;
 		case "enter-local-branch":
 			content = renderLocalBranchInput(wizard.repo, wizard.remoteRef, wizard.localBranch, cols);
+			break;
+		case "creating":
+			content = renderCreating(wizard.repo, wizard.message, cols, animFrame);
 			break;
 	}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,6 +99,11 @@ export type WizardStep =
 			remoteRef: string;
 			localBranch: string;
 			repos: RepoInfo[];
+	  }
+	| {
+			step: "creating";
+			repo: RepoInfo;
+			message: string;
 	  };
 
 export type WizardState = WizardStep | null;


### PR DESCRIPTION
## Summary
- セッション作成中（worktree作成、エディタ起動）にスピナーアニメーション付きの「creating」ステップを表示するように変更
- 全4つの作成パス（新規worktree、リモートブランチ、既存worktree、リポジトリルート）で非同期実行に切り替え、UIがブロックされないように修正
- 作成中のキー入力は無視し、誤操作を防止

Closes #8

## Test plan
- [x] 新規worktree作成時にスピナーが表示されることを確認
- [x] リモートブランチからの作成時にスピナーが表示されることを確認
- [x] 既存worktree選択時にスピナーが表示されることを確認
- [x] リポジトリルート開く時にスピナーが表示されることを確認
- [x] 作成完了後にウィザードが正常に閉じることを確認
- [x] 作成中にキー入力しても反応しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)