### PR TITLE
fix: prevent worktree agents from appearing under main-branch session

### DIFF
--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -12,7 +12,7 @@ import {
 import { disableRawMode, enableRawMode, parseKey, parseKeyWizard } from "./tui/input.ts";
 import { renderSidebar } from "./tui/render.ts";
 import { renderWizard } from "./tui/wizard.ts";
-import type { RepoInfo, SidebarState } from "./types.ts";
+import type { AgentState, RepoInfo, SidebarState } from "./types.ts";
 import { focusEditor, openEditor } from "./workspace/editor.ts";
 import {
 	cleanStaleAgents,
@@ -58,11 +58,27 @@ async function refreshSessions(state: SidebarState): Promise<void> {
 	const sessions = loadSessions();
 	const agentStates = loadAgentStates();
 
-	// Match agent states to sessions by cwd prefix
-	for (const session of sessions) {
-		session.agents = agentStates.filter(
-			(a) => a.cwd.startsWith(session.worktreePath) || a.sessionId === session.id,
-		);
+	// Match agent states to sessions by cwd prefix.
+	// Sort sessions by worktreePath length descending so that more specific
+	// paths (e.g. /repo/.wt/fix/foo) are matched before shorter prefixes
+	// (e.g. /repo), preventing worktree agents from also appearing under the
+	// main-branch session.
+	const sessionsByPathLen = [...sessions].sort(
+		(a, b) => b.worktreePath.length - a.worktreePath.length,
+	);
+	const assignedAgents = new Set<AgentState>();
+	for (const session of sessionsByPathLen) {
+		session.agents = agentStates.filter((a) => {
+			if (assignedAgents.has(a)) return false;
+			return (
+				a.sessionId === session.id ||
+				a.cwd.startsWith(`${session.worktreePath}/`) ||
+				a.cwd === session.worktreePath
+			);
+		});
+		for (const a of session.agents) {
+			assignedAgents.add(a);
+		}
 	}
 
 	// Detect editor window state for each session
@@ -104,7 +120,10 @@ async function refreshSessions(state: SidebarState): Promise<void> {
 				second: "2-digit",
 			});
 			const sessionIdx = sessions.findIndex(
-				(s) => agent.cwd.startsWith(s.worktreePath) || agent.sessionId === s.id,
+				(s) =>
+					agent.sessionId === s.id ||
+					agent.cwd === s.worktreePath ||
+					agent.cwd.startsWith(`${s.worktreePath}/`),
 			);
 			// Only add if not duplicate of last entry
 			const lastEntry = state.activityLog[state.activityLog.length - 1];

--- a/src/workspace/state.ts
+++ b/src/workspace/state.ts
@@ -116,7 +116,7 @@ export function cleanStaleAgents(): void {
 			// Orphan check: agent belongs to no known session (neither by id nor by cwd prefix)
 			const hasSession =
 				(parsed.sessionId && sessionIds.has(parsed.sessionId)) ||
-				sessionPaths.some((p) => parsed.cwd.startsWith(p));
+				sessionPaths.some((p) => parsed.cwd === p || parsed.cwd.startsWith(`${p}/`));
 			if (!hasSession) {
 				unlinkSync(filePath);
 				continue;
@@ -136,8 +136,11 @@ export function cleanStaleAgents(): void {
 
 export function findSessionByPath(cwd: string): string {
 	const sessions = loadSessions();
-	for (const session of sessions) {
-		if (cwd.startsWith(session.worktreePath)) {
+	// Sort by path length descending to match the most specific session first
+	// (e.g. /repo/.wt/fix/foo before /repo)
+	const sorted = [...sessions].sort((a, b) => b.worktreePath.length - a.worktreePath.length);
+	for (const session of sorted) {
+		if (cwd === session.worktreePath || cwd.startsWith(`${session.worktreePath}/`)) {
 			return session.id;
 		}
 	}


### PR DESCRIPTION
## Summary
- ワークツリーで起動したClaude Codeエージェントが、メインブランチのセッションにも重複表示されるバグを修正
  - `startsWith` によるパスマッチングで末尾 `/` を付加し、親ディレクトリの誤マッチを防止
  - セッションをパス長の降順でソートし、より具体的なパスを優先的にマッチさせることでエージェントの重複割り当てを排除
- デフォルトブランチ検出で `git remote show origin` をフォールバックに追加
  - ローカルの `symbolic-ref` が未設定でも、リモートの実際のデフォルトブランチ（develop等）を正しく検出
  - Fetch latest origin 機能が正しいデフォルトブランチを参照するように修正

## Test plan
- [x] `bun test` 全44テスト通過
- [x] TypeCheck通過
- [ ] メインブランチとワークツリーの両セッションがある状態で、ワークツリー側でClaude Codeを起動し、メインブランチ側に表示されないことを確認
- [ ] デフォルトブランチが `main` 以外のリポジトリで、Fetch latest origin が正しいブランチを参照することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)