### PR TITLE
fix: use remote HEAD branch for default branch detection

### DIFF
--- a/src/worktree/scanner.ts
+++ b/src/worktree/scanner.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import type { RepoInfo } from "../types.ts";
 
 async function getDefaultBranch(repoPath: string): Promise<string> {
+	// 1. Try local symbolic ref (fast, no network)
 	try {
 		const proc = Bun.spawn(["git", "-C", repoPath, "symbolic-ref", "refs/remotes/origin/HEAD"], {
 			stdout: "pipe",
@@ -19,7 +20,23 @@ async function getDefaultBranch(repoPath: string): Promise<string> {
 		// Fall through
 	}
 
-	// Fallback: check if main or master exists
+	// 2. Query remote for HEAD branch (requires network but authoritative)
+	try {
+		const proc = Bun.spawn(["git", "-C", repoPath, "remote", "show", "origin"], {
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const output = await new Response(proc.stdout).text();
+		await proc.exited;
+		if (proc.exitCode === 0) {
+			const match = output.match(/HEAD branch:\s*(.+)/);
+			if (match?.[1]) return match[1].trim();
+		}
+	} catch {
+		// Fall through
+	}
+
+	// 3. Fallback: check if main or master exists locally
 	try {
 		const proc = Bun.spawn(["git", "-C", repoPath, "branch", "--list", "main", "master"], {
 			stdout: "pipe",


### PR DESCRIPTION
## Summary
- デフォルトブランチ検出で `git remote show origin` をフォールバックに追加
- ローカルの `symbolic-ref` が未設定の場合でも、リモートの実際のデフォルトブランチ（develop等）を正しく検出
- 検出順: `symbolic-ref`（ローカル高速） → `git remote show origin`（リモート問い合わせ） → `main`/`master` ローカル存在チェック

## Test plan
- [x] `bun test` 全44テスト通過
- [x] TypeCheck通過
- [x] デフォルトブランチが `main` 以外のリポジトリで、Fetch latest origin が正しいブランチを参照することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)