### PR TITLE
fix: address open issues #23-#25 (notification latency, debounce, editor usage)

### DIFF
--- a/src/agent/hook.ts
+++ b/src/agent/hook.ts
@@ -99,6 +99,8 @@ const STATUS_MAP: Record<string, string> = {
 
 const ATTENTION_EVENTS = new Set(["PermissionRequest", "Notification"]);
 
+const NOTIFY_DEBOUNCE_MS = 3000;
+
 function pickSoundFile(eventName: string, sound: HubConfig["sound"]): string {
 	if (eventName === "PermissionRequest") return sound.permission_request;
 	return sound.notification;
@@ -107,10 +109,23 @@ function pickSoundFile(eventName: string, sound: HubConfig["sound"]): string {
 /**
  * Macos Notification Center plays its own sound, so when we post one we
  * suppress the standalone afplay path to avoid a double-beep.
+ *
+ * Skips emission entirely when the previous alert for this agent fired within
+ * NOTIFY_DEBOUNCE_MS — Claude Code can emit Notification (idle_prompt) and
+ * Stop back-to-back at turn end, which would otherwise double-beep.
+ *
+ * Returns true when a notification or sound was emitted so the caller can
+ * record `lastNotifiedAt`.
  */
-function reactToEvent(eventName: string, payload: Record<string, unknown>): void {
-	if (process.env.CCDOCK_SILENT === "1") return;
-	if (process.platform !== "darwin") return;
+function reactToEvent(
+	eventName: string,
+	payload: Record<string, unknown>,
+	lastNotifiedAt: number | undefined,
+	now: number,
+): boolean {
+	if (process.env.CCDOCK_SILENT === "1") return false;
+	if (process.platform !== "darwin") return false;
+	if (lastNotifiedAt !== undefined && now - lastNotifiedAt < NOTIFY_DEBOUNCE_MS) return false;
 
 	const config = loadConfig();
 	const soundFile = pickSoundFile(eventName, config.sound);
@@ -127,15 +142,23 @@ function reactToEvent(eventName: string, payload: Record<string, unknown>): void
 			message: message || eventName,
 			sound: config.sound.enabled ? soundNameFromPath(soundFile) : undefined,
 		});
-		return;
+		return true;
 	}
 
-	if (!ATTENTION_EVENTS.has(eventName)) return;
-	if (!config.sound.enabled || !soundFile) return;
+	if (!ATTENTION_EVENTS.has(eventName)) return false;
+	if (!config.sound.enabled || !soundFile) return false;
 	try {
-		Bun.spawn(["afplay", soundFile], { stdout: "ignore", stderr: "ignore" });
+		// Detach so the hook can return without blocking on afplay's playback
+		// duration — otherwise the parent agent waits for the sound to finish.
+		const proc = Bun.spawn(["afplay", soundFile], {
+			stdout: "ignore",
+			stderr: "ignore",
+		});
+		proc.unref();
+		return true;
 	} catch {
 		// afplay missing — ignore.
+		return false;
 	}
 }
 
@@ -174,17 +197,19 @@ export async function handleHook(agentType: string, eventName: string): Promise<
 		return;
 	}
 
-	// Audible / visual cue.
 	// Sounds always fire on PermissionRequest / Notification (legacy default);
 	// Mac notifications fire on whatever events the config subscribes to.
-	reactToEvent(eventName, payload);
+	const prevState = readAgentState(filename);
+	const now = Date.now();
+	const emitted = reactToEvent(eventName, payload, prevState?.lastNotifiedAt, now);
+	const lastNotifiedAt = emitted ? now : prevState?.lastNotifiedAt;
 
 	// Notification doesn't carry meaningful status info — preserve previous state
 	if (eventName === "Notification") {
-		const prev = readAgentState(filename);
-		if (prev) {
-			prev.updatedAt = Date.now();
-			writeAgentState(prev, filename);
+		if (prevState) {
+			prevState.updatedAt = now;
+			if (lastNotifiedAt !== undefined) prevState.lastNotifiedAt = lastNotifiedAt;
+			writeAgentState(prevState, filename);
 		}
 		return;
 	}
@@ -199,12 +224,9 @@ export async function handleHook(agentType: string, eventName: string): Promise<
 	// but clear them on Stop (stopped) since the agent is no longer doing anything
 	let toolName = rawToolName;
 	let toolDetail = rawToolDetail;
-	if (!toolName && status !== "stopped") {
-		const prev = readAgentState(filename);
-		if (prev) {
-			toolName = prev.toolName ?? "";
-			toolDetail = prev.toolDetail ?? "";
-		}
+	if (!toolName && status !== "stopped" && prevState) {
+		toolName = prevState.toolName ?? "";
+		toolDetail = prevState.toolDetail ?? "";
 	}
 
 	// Hook is spawned by the agent process, so process.ppid points at the agent.
@@ -217,8 +239,9 @@ export async function handleHook(agentType: string, eventName: string): Promise<
 		toolName,
 		toolDetail,
 		cwd,
-		updatedAt: Date.now(),
+		updatedAt: now,
 		pid: process.ppid,
+		lastNotifiedAt,
 	};
 
 	writeAgentState(state, filename);

--- a/src/agent/notify.ts
+++ b/src/agent/notify.ts
@@ -54,7 +54,11 @@ function postViaTerminalNotifier(bin: string, opts: NotifyOptions): boolean {
 	if (opts.sound) args.push("-sound", opts.sound);
 
 	try {
-		Bun.spawn(args, { stdout: "ignore", stderr: "ignore" });
+		// Detach so the short-lived hook process can exit immediately instead of
+		// waiting for terminal-notifier's GUI bookkeeping to finish. Without this,
+		// the notification only surfaces after the hook returns (~hundreds of ms).
+		const proc = Bun.spawn(args, { stdout: "ignore", stderr: "ignore" });
+		proc.unref();
 		return true;
 	} catch {
 		return false;
@@ -71,7 +75,11 @@ function postViaOsascript(opts: NotifyOptions): void {
 
 	const script = `display notification "${message}" with title "${title}"${subtitleClause}${soundClause}`;
 	try {
-		Bun.spawn(["osascript", "-e", script], { stdout: "ignore", stderr: "ignore" });
+		const proc = Bun.spawn(["osascript", "-e", script], {
+			stdout: "ignore",
+			stderr: "ignore",
+		});
+		proc.unref();
 	} catch {
 		// osascript missing — silently ignore.
 	}

--- a/src/agent/usage.ts
+++ b/src/agent/usage.ts
@@ -1,40 +1,80 @@
+import type { ProcUsage } from "../types.ts";
+
+export type { ProcUsage };
+
+const kbToMb = (kb: number): number => Math.round(kb / 1024);
+
+async function runPsLines(args: string[]): Promise<string[]> {
+	try {
+		const proc = Bun.spawn(args, { stdout: "pipe", stderr: "ignore" });
+		const out = await new Response(proc.stdout).text();
+		await proc.exited;
+		const lines: string[] = [];
+		for (const line of out.split("\n")) {
+			const trimmed = line.trim();
+			if (trimmed) lines.push(trimmed);
+		}
+		return lines;
+	} catch {
+		return [];
+	}
+}
+
 /**
  * Sample CPU% and RSS memory for a set of pids in one `ps` call.
  *
  * Returns a map keyed by pid. Pids that aren't alive (or aren't reported by
  * ps for any reason) are simply absent from the result.
  */
-export interface ProcUsage {
-	cpuPercent: number;
-	memoryMb: number;
-}
-
 export async function sampleProcessUsage(pids: number[]): Promise<Map<number, ProcUsage>> {
 	const result = new Map<number, ProcUsage>();
 	const unique = Array.from(new Set(pids.filter((p) => Number.isFinite(p) && p > 0)));
 	if (unique.length === 0) return result;
 
-	const args = ["ps", "-o", "pid=,pcpu=,rss=", "-p", unique.join(",")];
-	try {
-		const proc = Bun.spawn(args, { stdout: "pipe", stderr: "ignore" });
-		const out = await new Response(proc.stdout).text();
-		await proc.exited;
-		for (const line of out.split("\n")) {
-			const trimmed = line.trim();
-			if (!trimmed) continue;
-			const parts = trimmed.split(/\s+/);
-			if (parts.length < 3) continue;
-			const pid = Number.parseInt(parts[0]!, 10);
-			const cpu = Number.parseFloat(parts[1]!);
-			const rssKb = Number.parseInt(parts[2]!, 10);
-			if (!Number.isFinite(pid) || !Number.isFinite(cpu) || !Number.isFinite(rssKb)) continue;
-			result.set(pid, {
-				cpuPercent: cpu,
-				memoryMb: Math.round(rssKb / 1024),
-			});
-		}
-	} catch {
-		// ps unavailable — return whatever we collected (likely empty).
+	const lines = await runPsLines(["ps", "-o", "pid=,pcpu=,rss=", "-p", unique.join(",")]);
+	for (const line of lines) {
+		const parts = line.split(/\s+/);
+		if (parts.length < 3) continue;
+		const pid = Number.parseInt(parts[0]!, 10);
+		const cpu = Number.parseFloat(parts[1]!);
+		const rssKb = Number.parseInt(parts[2]!, 10);
+		if (!Number.isFinite(pid) || !Number.isFinite(cpu) || !Number.isFinite(rssKb)) continue;
+		result.set(pid, { cpuPercent: cpu, memoryMb: kbToMb(rssKb) });
 	}
 	return result;
+}
+
+/**
+ * Aggregate CPU% and RSS across every process whose command matches one of
+ * the given patterns (case-insensitive substring match).
+ *
+ * VS Code spawns one main Electron process plus a handful of `Code Helper`
+ * processes (renderer, GPU, extension host, utility…) per window. We sum all
+ * of them so the sidebar reports the user's actual editor footprint, not just
+ * one helper. Returns `null` when no matching process is alive.
+ */
+export async function sampleAppUsageByName(patterns: string[]): Promise<ProcUsage | null> {
+	if (patterns.length === 0) return null;
+	const lowered = patterns.map((p) => p.toLowerCase());
+
+	const lines = await runPsLines(["ps", "-axo", "pcpu=,rss=,command="]);
+	let totalCpu = 0;
+	let totalRssKb = 0;
+	let matched = 0;
+	for (const line of lines) {
+		// Cheap substring filter before splitting — ps -axo emits one line per
+		// running process, so most lines won't match any pattern.
+		const loweredLine = line.toLowerCase();
+		if (!lowered.some((p) => loweredLine.includes(p))) continue;
+		const parts = line.split(/\s+/);
+		if (parts.length < 3) continue;
+		const cpu = Number.parseFloat(parts[0]!);
+		const rssKb = Number.parseInt(parts[1]!, 10);
+		if (!Number.isFinite(cpu) || !Number.isFinite(rssKb)) continue;
+		totalCpu += cpu;
+		totalRssKb += rssKb;
+		matched++;
+	}
+	if (matched === 0) return null;
+	return { cpuPercent: totalCpu, memoryMb: kbToMb(totalRssKb) };
 }

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -11,8 +11,8 @@ import {
 import { disableRawMode, enableRawMode, parseKey, parseKeyWizard } from "./tui/input.ts";
 import { renderSidebar } from "./tui/render.ts";
 import { renderWizard } from "./tui/wizard.ts";
-import type { AgentState, RepoInfo, SidebarState } from "./types.ts";
-import { focusEditor, openEditor } from "./workspace/editor.ts";
+import type { AgentState, HubConfig, RepoInfo, SidebarState } from "./types.ts";
+import { editorProcessPatterns, focusEditor, openEditor } from "./workspace/editor.ts";
 import {
 	cleanStaleAgents,
 	deleteSession,
@@ -28,14 +28,14 @@ import {
 } from "./worktree/manager.ts";
 import { listRemoteBranches } from "./worktree/remote.ts";
 import { scanRepos } from "./worktree/scanner.ts";
-import { sampleProcessUsage } from "./agent/usage.ts";
+import { sampleAppUsageByName, sampleProcessUsage } from "./agent/usage.ts";
 
 function sessionNameFromBranch(branchName: string): string {
 	const parts = branchName.split("/");
 	return parts[parts.length - 1] ?? branchName;
 }
 
-function createInitialState(): SidebarState {
+function createInitialState(editor: HubConfig["editor"]): SidebarState {
 	const [rows, cols] = [process.stdout.rows ?? 24, process.stdout.columns ?? 80];
 	return {
 		sessions: [],
@@ -51,6 +51,8 @@ function createInitialState(): SidebarState {
 		deleteConfirm: null,
 		quitConfirm: null,
 		deletingSessionIds: new Set(),
+		editor,
+		editorUsage: null,
 	};
 }
 
@@ -63,10 +65,18 @@ async function refreshSessions(state: SidebarState): Promise<void> {
 		.filter((a) => a.status === "running" || a.status === "waiting" || a.status === "idle")
 		.map((a) => a.pid)
 		.filter((p): p is number => typeof p === "number" && p > 0);
+	// Skip the system-wide `ps -axo` scan when no session has an editor window
+	// open — saves the per-refresh cost on machines with hundreds of processes.
+	const needEditorUsage = state.sessions.some((s) => s.editorState !== "closed");
+	const [agentUsage, editorUsage] = await Promise.all([
+		livePids.length > 0 ? sampleProcessUsage(livePids) : Promise.resolve(new Map()),
+		needEditorUsage
+			? sampleAppUsageByName(editorProcessPatterns(state.editor))
+			: Promise.resolve(null),
+	]);
 	if (livePids.length > 0) {
-		const usage = await sampleProcessUsage(livePids);
 		for (const a of agentStates) {
-			const sample = a.pid ? usage.get(a.pid) : undefined;
+			const sample = a.pid ? agentUsage.get(a.pid) : undefined;
 			if (sample) {
 				a.cpuPercent = sample.cpuPercent;
 				a.memoryMb = sample.memoryMb;
@@ -76,6 +86,7 @@ async function refreshSessions(state: SidebarState): Promise<void> {
 			}
 		}
 	}
+	state.editorUsage = editorUsage;
 
 	// Match agent states to sessions by cwd prefix.
 	// Sort sessions by worktreePath length descending so that more specific
@@ -619,7 +630,7 @@ function getManagedWindows(sessions: SidebarState["sessions"]): { worktreePath: 
 
 export async function runSidebar(): Promise<void> {
 	const config = loadConfig();
-	const state = createInitialState();
+	const state = createInitialState(config.editor);
 
 	// Initial load
 	await refreshSessions(state);

--- a/src/tui/ansi.ts
+++ b/src/tui/ansi.ts
@@ -125,6 +125,10 @@ export function truncate(str: string, maxLen: number): string {
 	return result;
 }
 
+export function formatMem(mb: number): string {
+	return mb >= 1024 ? `${(mb / 1024).toFixed(1)}G` : `${mb}M`;
+}
+
 export function shortenHome(path: string): string {
 	const home = process.env.HOME ?? "";
 	if (home && path.startsWith(home)) {

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -21,6 +21,7 @@ import {
 	DIM,
 	RESET,
 	clearLine,
+	formatMem,
 	moveCursor,
 	shortenHome,
 	statusColor,
@@ -187,7 +188,14 @@ function renderCard(
 	return lines;
 }
 
-function renderUsageSummary(state: SidebarState): string {
+const USAGE_LABEL_WIDTH = 6;
+
+function formatUsageRow(label: string, cpu: number, mem: number, suffix = ""): string {
+	const paddedLabel = padRight(label, USAGE_LABEL_WIDTH);
+	return ` ${COLORS.muted}${paddedLabel}${RESET} ${BOLD}${cpu.toFixed(1)}%${RESET} ${COLORS.muted}/${RESET} ${BOLD}${formatMem(mem)}${RESET}${suffix}`;
+}
+
+function renderUsageSummary(state: SidebarState): string[] {
 	let totalCpu = 0;
 	let totalMem = 0;
 	let live = 0;
@@ -198,9 +206,15 @@ function renderUsageSummary(state: SidebarState): string {
 			if (typeof agent.pid === "number") live++;
 		}
 	}
-	const memText = totalMem >= 1024 ? `${(totalMem / 1024).toFixed(1)}G` : `${totalMem}M`;
 	const agentLabel = live === 1 ? "agent" : "agents";
-	return ` ${COLORS.muted}CPU${RESET} ${BOLD}${totalCpu.toFixed(1)}%${RESET} ${COLORS.muted}MEM${RESET} ${BOLD}${memText}${RESET} ${COLORS.muted}(${live} ${agentLabel})${RESET}`;
+	const agentSuffix = ` ${COLORS.muted}(${live} ${agentLabel})${RESET}`;
+	const lines = [formatUsageRow("AGENT", totalCpu, totalMem, agentSuffix)];
+
+	const editor = state.editorUsage;
+	if (editor) {
+		lines.push(formatUsageRow("EDITOR", editor.cpuPercent, editor.memoryMb));
+	}
+	return lines;
 }
 
 function renderActivityLog(state: SidebarState, maxLines: number): string[] {
@@ -290,7 +304,8 @@ export function renderSidebar(state: SidebarState): string {
 	const footerHeight = 3;
 	const headerHeight = 2;
 	const logHeight = state.showActivityLog ? Math.min(8, state.activityLog.length + 2) : 0;
-	const usageHeight = 1;
+	const usageLines = renderUsageSummary(state);
+	const usageHeight = usageLines.length;
 	const availableForCards = state.rows - headerHeight - footerHeight - logHeight - usageHeight;
 
 	// Render session cards
@@ -336,8 +351,7 @@ export function renderSidebar(state: SidebarState): string {
 		output.push("");
 	}
 
-	// Aggregate CPU / memory across all live agents
-	output.push(renderUsageSummary(state));
+	output.push(...usageLines);
 
 	// Activity log
 	if (state.showActivityLog) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,11 @@
 export type AgentType = "claude-code" | "codex";
 export type AgentStatus = "running" | "waiting" | "idle" | "stopped" | "error" | "unknown";
 
+export interface ProcUsage {
+	cpuPercent: number;
+	memoryMb: number;
+}
+
 export interface AgentState {
 	sessionId: string;
 	agentType: AgentType;
@@ -13,6 +18,7 @@ export interface AgentState {
 	pid?: number; // process id of the agent (parent of the hook), used for ps lookup
 	cpuPercent?: number; // sampled by the sidebar from `ps -p <pid>`
 	memoryMb?: number; // RSS in MiB, also sampled from `ps`
+	lastNotifiedAt?: number; // Date.now() of the last notification/sound emitted for this agent
 }
 
 export type EditorState = "focused" | "open" | "closed" | "launching";
@@ -67,6 +73,8 @@ export interface SidebarState {
 	deleteConfirm: DeleteConfirm | null;
 	quitConfirm: { selectedIndex: number } | null; // 0=quit only, 1=quit+close editors
 	deletingSessionIds: Set<string>;
+	editor: HubConfig["editor"];
+	editorUsage: ProcUsage | null;
 }
 
 // Wizard steps for creating new sessions

--- a/src/workspace/editor.ts
+++ b/src/workspace/editor.ts
@@ -1,9 +1,23 @@
+import type { HubConfig } from "../types.ts";
 import {
 	editorWindowExists,
 	focusAndPositionEditor,
 	getSidebarBounds,
 	positionEditorWindow,
 } from "./window.ts";
+
+// VS Code (and Cursor, which forks the same Electron app) splits each window
+// across one main process plus several `* Helper` processes (renderer, GPU,
+// extension host, utility). Match the umbrella app names so usage sampling
+// catches all of them.
+const EDITOR_PROCESS_PATTERNS: Record<HubConfig["editor"], string[]> = {
+	code: ["Visual Studio Code.app/", "Code Helper"],
+	cursor: ["Cursor.app/", "Cursor Helper"],
+};
+
+export function editorProcessPatterns(editor: HubConfig["editor"]): string[] {
+	return EDITOR_PROCESS_PATTERNS[editor] ?? EDITOR_PROCESS_PATTERNS.code;
+}
 
 export async function openEditor(worktreePath: string, editor: string): Promise<void> {
 	Bun.spawn([editor, "--new-window", worktreePath], {


### PR DESCRIPTION
## Summary

オープン中の3つのissue (#23, #24, #25) に対応。

### #23 Push通知のタイミングが遅い
`terminal-notifier` / `osascript` / `afplay` の `Bun.spawn` 結果に `proc.unref()` を呼び、子プロセスの終了を待たずに hook が return できるようにした。
- 実測: hook 1 回あたり **130-140ms → 30-50ms** (約4倍速)

### #24 waitingの通知とstop通知が両方なってしまう
`AgentState` に `lastNotifiedAt` を追加し、`reactToEvent` 内で `NOTIFY_DEBOUNCE_MS` (3秒) 以内の連続通知を抑止。Claude Code が `Notification` (idle_prompt / permission_prompt) と `Stop` を連続発火するケースで二重通知を防ぐ。

### #25 開いているVSCodeのCPU、メモリ使用料も一緒にモニタリングしたい
`usage.ts` に `sampleAppUsageByName` を追加し、`ps -axo pcpu=,rss=,command=` の出力を substring マッチして VS Code/Cursor の本体 + 全 Helper プロセス (Renderer / GPU / Extension Host / Utility) を集計。
- サイドバー下部に独立した `EDITOR` 行として表示
- editor window が 1 つも開いていない時はサンプリング自体をスキップしてホットパスを軽量化
- 実測 (VS Code multi-window時): 65プロセスを正しく集計、`ps`直接集計と1MB差以内

```
 AGENT  0.0% / 0M (0 agents)
 EDITOR 25.0% / 5.7G
```

### その他リファクタリング
- `ProcUsage` 型を `types.ts` に集約、`SidebarState.editorUsage` で再利用
- `editorProcessPatterns` を `workspace/editor.ts` に移動し `Record<HubConfig["editor"], string[]>` で型付け
- `editor` を `SidebarState` に持たせ、`refreshSessions` / `handleDeleteConfirmInput` から引数を撤去
- `sampleProcessUsage` と `sampleAppUsageByName` で `runPsLines` / `kbToMb` を共通化
- `formatMem` を `tui/ansi.ts` に移動、AGENT/EDITOR 行を `formatUsageRow` で共通化 (ラベル幅 6 で `padRight`)

## Test plan

- [x] `bun run typecheck` 通過
- [x] `bun run format` 通過
- [x] `bun test` 68 pass / 0 fail
- [x] #23: 修正前後の hook 実行時間を `/usr/bin/time -p` で5回計測し、約4倍速を確認
- [x] #24: PreToolUse → PermissionRequest → (0.5s) Stop → (4s) PermissionRequest の順で投入し、`lastNotifiedAt` が以下を満たすことを確認
  - T1 == T2 (デバウンス枠内で抑止)
  - T3 > T1 (枠抜け後に再 emission)
- [x] #25: `sampleAppUsageByName(editorProcessPatterns("code"))` の結果が `ps` 直接集計とほぼ一致することを確認 (5841MB vs 5842MB)
- [x] #25: editor が 1 つも開いていない時 `needEditorUsage = false` でサンプリングがスキップされることを確認
- [ ] 実環境で Claude Code を起動し、通知の体感速度が改善していること
- [ ] 実環境で sidebar フッターに `EDITOR ...` 行が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)