### PR TITLE
fix: stabilize subagent status tracking and detect broken hooks

### DIFF
--- a/src/agent/hook-check.ts
+++ b/src/agent/hook-check.ts
@@ -1,0 +1,40 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+interface HookEntry {
+	matcher?: string;
+	hooks?: Array<{ type?: string; command?: string }>;
+}
+
+interface ClaudeSettings {
+	hooks?: Record<string, HookEntry[]>;
+}
+
+// Detects ccdock hook commands registered in ~/.claude/settings.json whose
+// executable no longer resolves. If the ccdock binary path becomes a dangling
+// symlink (e.g. after a bun install/upgrade), every hook invocation exits 127
+// and notifications/status updates silently stop working.
+export function findBrokenHookCommands(settingsPath?: string): string[] {
+	const path = settingsPath ?? join(process.env.HOME ?? "", ".claude", "settings.json");
+	try {
+		const settings: ClaudeSettings = JSON.parse(readFileSync(path, "utf8"));
+		const broken = new Set<string>();
+		for (const entries of Object.values(settings.hooks ?? {})) {
+			for (const entry of entries) {
+				for (const hook of entry.hooks ?? []) {
+					const command = hook.command;
+					if (!command || !command.includes("ccdock")) continue;
+					const executable = command.split(/\s+/)[0];
+					if (!executable) continue;
+					const isBroken = executable.includes("/")
+						? !existsSync(executable)
+						: Bun.which(executable) === null;
+					if (isBroken) broken.add(executable);
+				}
+			}
+		}
+		return [...broken];
+	} catch {
+		return [];
+	}
+}

--- a/src/agent/hook.ts
+++ b/src/agent/hook.ts
@@ -190,19 +190,20 @@ export async function handleHook(agentType: string, eventName: string): Promise<
 		return;
 	}
 
-	// Subagents (Task tool) inherit a fresh session_id but are already represented
-	// by the parent's Task tool entry — writing a separate agent file would
-	// duplicate them as independent agents on the sidebar. Detect via
-	// parent_tool_use_id, which Claude Code sets only on subagent invocations.
+	// Older Claude Code versions fired subagent (Task tool) events with a fresh
+	// session_id plus parent_tool_use_id, which would create duplicate agent
+	// rows — skip those. Current versions (observed on 2.1.x) share the
+	// parent's session_id and omit the field, so subagent events fall through
+	// and simply count as activity of the parent session below.
 	if (payload.parent_tool_use_id) {
 		return;
 	}
 
-	// By extension, SubagentStop is never handled either — it isn't in
-	// STATUS_MAP or the documented hooks setup, so subagent completion never
-	// reaches here and never triggers a notification.
-
-	const filename = `${sanitize(cwd)}-${claudeSessionId}.json`;
+	// One state file per Claude session: subagent events (same session_id, but
+	// possibly a different cwd such as a scratchpad or isolated worktree) update
+	// the same file instead of spawning per-cwd ghost entries. Files from the
+	// older `<cwd>-<session_id>` naming are migrated away by cleanStaleAgents.
+	const filename = `${sanitize(claudeSessionId)}.json`;
 
 	const mappedStatus = STATUS_MAP[eventName];
 
@@ -229,7 +230,15 @@ export async function handleHook(agentType: string, eventName: string): Promise<
 	}
 
 	const status = mappedStatus ?? "unknown";
-	const sessionId = findSessionByPath(cwd);
+	// Subagents can run in a cwd outside any session (scratchpad, isolated
+	// worktree). Keep the previously mapped cwd in that case so the sidebar
+	// keeps attributing the activity to the right session.
+	let sessionId = findSessionByPath(cwd);
+	let agentCwd = cwd;
+	if (!sessionId && prevState) {
+		agentCwd = prevState.cwd;
+		sessionId = prevState.sessionId || findSessionByPath(agentCwd);
+	}
 	const rawToolName = (payload.tool_name as string) ?? "";
 	const toolInput = (payload.tool_input as Record<string, unknown>) ?? {};
 	const rawToolDetail = extractToolDetail(agentType as AgentType, rawToolName, toolInput);
@@ -252,7 +261,7 @@ export async function handleHook(agentType: string, eventName: string): Promise<
 		prompt: buildPrompt(eventName, payload),
 		toolName,
 		toolDetail,
-		cwd,
+		cwd: agentCwd,
 		updatedAt: now,
 		pid: process.ppid,
 		lastNotifiedAt,

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -25,6 +25,7 @@ import {
 } from "./workspace/state.ts";
 import { createWorktree, listWorktrees, removeWorktree } from "./worktree/manager.ts";
 import { scanRepos } from "./worktree/scanner.ts";
+import { findBrokenHookCommands } from "./agent/hook-check.ts";
 import { sampleAppUsageByName, sampleProcessUsage } from "./agent/usage.ts";
 
 function sessionNameFromBranch(branchName: string): string {
@@ -54,6 +55,7 @@ function createInitialState(editor: HubConfig["editor"]): SidebarState {
 		editor,
 		editorUsage: null,
 		worktreeDiffs: new Map(),
+		hookWarning: null,
 		sidebarWindowId: null,
 	};
 }
@@ -691,6 +693,14 @@ export async function runSidebar(): Promise<void> {
 	process.stdout.write(`\x1b]2;${sidebarTitle}\x07`);
 	await Bun.sleep(250);
 	state.sidebarWindowId = await getSidebarGhosttyWindowId(sidebarTitle);
+
+	// Detect broken ccdock hook commands once at startup (e.g. a dangling
+	// symlink after a bun install/upgrade breaks notifications silently).
+	const brokenHooks = findBrokenHookCommands();
+	state.hookWarning =
+		brokenHooks.length > 0
+			? `Claude Code hook broken: ${brokenHooks[0]} not found (notifications/status frozen)`
+			: null;
 
 	// Initial load
 	await refreshSessions(state);

--- a/src/tui/ansi.ts
+++ b/src/tui/ansi.ts
@@ -104,20 +104,6 @@ export function statusBadge(status: string): string {
 	return `${bg}${BLACK_FG}${BOLD} ${label} ${RESET}`;
 }
 
-// Logo-style agent icons in place of the type name. The official Claude brand
-// glyph is not in Nerd Fonts yet (https://github.com/ryanoasis/nerd-fonts/issues/2001);
-// swap these for the official codepoints once a release ships them. Until then:
-// Claude's starburst in brand orange, Codex as a filled hexagon — bold and the
-// visually largest plain-Unicode shapes available.
-export function agentTypeIcon(type: string): string {
-	switch (type) {
-		case "claude-code":
-			return `${BOLD}${fg256(173)}✺${RESET}`;
-		default:
-			return `${BOLD}${fg256(252)}⬢${RESET}`;
-	}
-}
-
 function statusBadgeLabel(status: string): string {
 	switch (status) {
 		case "running":

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -34,7 +34,6 @@ import {
 	moveCursor,
 	shortenHome,
 	statusBadge,
-	agentTypeIcon,
 	statusColor,
 	statusIcon,
 	truncate,
@@ -242,9 +241,9 @@ function renderCard(
 			lines.push(agentLine);
 		} else {
 			for (const agent of session.agents) {
-				// Agent row: [ STATUS ] pill + agent logo icon.
+				// Agent row: [ STATUS ] pill + agent type name.
 				const badge = statusBadge(agent.status);
-				const agentInfo = `${badge} ${agentTypeIcon(agent.agentType)}`;
+				const agentInfo = `${badge} ${detailColor}${agent.agentType}${RESET}`;
 				const agentLine = boxLine(agentInfo, width, borderColor, dimAll);
 				lines.push(agentLine);
 
@@ -434,11 +433,14 @@ export function renderSidebar(state: SidebarState): string {
 	// Header
 	const header = `${BOLD}${COLORS.highlight} ccdock${RESET} ${COLORS.muted}(${state.sessions.length} sessions)${RESET}`;
 	output.push(header);
+	if (state.hookWarning) {
+		output.push(`${COLORS.waiting}⚠ ${truncate(state.hookWarning, state.cols - 3)}${RESET}`);
+	}
 	output.push("");
 
 	// Calculate available space
 	const footerHeight = 3;
-	const headerHeight = 2;
+	const headerHeight = state.hookWarning ? 3 : 2;
 	const logHeight = state.showActivityLog ? Math.min(8, state.activityLog.length + 2) : 0;
 	const usageLines = renderUsageSummary(state);
 	const usageHeight = usageLines.length;

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,6 +109,11 @@ export interface SidebarState {
 	 */
 	worktreeDiffs: Map<string, WorktreeDiff | null>;
 	/**
+	 * Warning message when a registered ccdock hook command is broken (e.g. a
+	 * dangling symlink), computed once at startup. null when hooks are healthy.
+	 */
+	hookWarning: string | null;
+	/**
 	 * Ghostty window id of the sidebar's own terminal, captured once at startup.
 	 * ccdock runs inside Ghostty, so this window must be excluded from every
 	 * list/close/reposition/focus operation. null when ccdock is not running

--- a/src/workspace/state.ts
+++ b/src/workspace/state.ts
@@ -123,6 +123,15 @@ export function cleanStaleAgents(): void {
 	for (const file of files) {
 		try {
 			const filePath = join(agentsDir, file);
+
+			// Migration: a legacy `<sanitized cwd>-<session id>.json` file is
+			// superseded by its session-keyed twin `<session id>.json`.
+			const stem = file.slice(0, -".json".length);
+			if (files.some((f) => f !== file && stem.endsWith(`-${f.slice(0, -".json".length)}`))) {
+				unlinkSync(filePath);
+				continue;
+			}
+
 			const raw = readFileSync(filePath, "utf-8");
 			const parsed = JSON.parse(raw) as AgentState;
 

--- a/test/hook-check.test.ts
+++ b/test/hook-check.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { findBrokenHookCommands } from "../src/agent/hook-check.ts";
+
+let dir: string;
+
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "ccdock-hook-check-"));
+});
+
+afterEach(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+function writeSettings(command: string): string {
+	const settingsPath = join(dir, "settings.json");
+	writeFileSync(
+		settingsPath,
+		JSON.stringify({
+			hooks: {
+				PreToolUse: [{ matcher: "", hooks: [{ type: "command", command }] }],
+			},
+		}),
+	);
+	return settingsPath;
+}
+
+describe("findBrokenHookCommands", () => {
+	test("reports a ccdock command whose absolute path does not exist", () => {
+		const missingPath = join(dir, "nonexistent-ccdock");
+		const settingsPath = writeSettings(`${missingPath} hook claude-code PreToolUse`);
+		expect(findBrokenHookCommands(settingsPath)).toEqual([missingPath]);
+	});
+
+	test("does not report a ccdock command whose path exists", () => {
+		const existingPath = join(dir, "ccdock-bin");
+		writeFileSync(existingPath, "");
+		const settingsPath = writeSettings(`${existingPath} hook claude-code PreToolUse`);
+		expect(findBrokenHookCommands(settingsPath)).toEqual([]);
+	});
+});

--- a/test/hook.test.ts
+++ b/test/hook.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentState } from "../src/types.ts";
@@ -20,7 +28,7 @@ async function runHook(event: string, payload: Record<string, unknown>): Promise
 		stdin: "pipe",
 		stdout: "pipe",
 		stderr: "pipe",
-		env: { ...process.env, XDG_STATE_HOME: stateRoot },
+		env: { ...process.env, XDG_STATE_HOME: stateRoot, CCDOCK_SILENT: "1" },
 	});
 	proc.stdin.write(JSON.stringify(payload));
 	await proc.stdin.end();
@@ -29,6 +37,24 @@ async function runHook(event: string, payload: Record<string, unknown>): Promise
 
 function agentsDir(): string {
 	return join(stateRoot, "ccdock", "agents");
+}
+
+function registerSession(id: string, worktreePath: string): void {
+	const dir = join(stateRoot, "ccdock", "sessions");
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(
+		join(dir, `${id}.json`),
+		JSON.stringify({
+			id,
+			sessionName: id,
+			worktreePath,
+			branch: "main",
+			repoName: "repo",
+			editorState: "closed",
+			createdAt: 1,
+			lastActiveAt: 1,
+		}),
+	);
 }
 
 function readOnlyAgent(): AgentState {
@@ -145,5 +171,27 @@ describe("ccdock hook", () => {
 		if (existsSync(agentsDir())) {
 			expect(readdirSync(agentsDir()).length).toBe(0);
 		}
+	});
+
+	test("subagent event from an unmapped cwd updates the same file and keeps the mapped cwd", async () => {
+		registerSession("s1", "/tmp/workspace/repo");
+		await runHook("PreToolUse", {
+			session_id: "sess-abc",
+			cwd: "/tmp/workspace/repo",
+			tool_name: "Bash",
+			tool_input: { command: "ls" },
+		});
+		// Same session, but the event originates from a scratchpad-style cwd
+		// that maps to no known session.
+		await runHook("PreToolUse", {
+			session_id: "sess-abc",
+			cwd: "/tmp/some-scratchpad/dir",
+			tool_name: "Write",
+			tool_input: { file_path: "/tmp/some-scratchpad/dir/x" },
+		});
+		const state = readOnlyAgent();
+		expect(state.cwd).toBe("/tmp/workspace/repo");
+		expect(state.sessionId).toBe("s1");
+		expect(state.toolName).toBe("Write");
 	});
 });

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -91,6 +91,16 @@ describe("cleanStaleAgents", () => {
 		expect(existsSync(p)).toBe(true);
 	});
 
+	test("removes legacy per-cwd file once the session-keyed twin exists", async () => {
+		const { cleanStaleAgents } = await import(`../src/workspace/state.ts?t=${Date.now()}`);
+		writeSession(buildSession());
+		const legacy = writeAgent("_tmp_repo-sess-uuid-1.json", buildAgent({ status: "stopped" }));
+		const current = writeAgent("sess-uuid-1.json", buildAgent({ status: "running" }));
+		cleanStaleAgents();
+		expect(existsSync(legacy)).toBe(false);
+		expect(existsSync(current)).toBe(true);
+	});
+
 	test("removes transient (running) agent older than 30 minutes", async () => {
 		const { cleanStaleAgents } = await import(`../src/workspace/state.ts?t=${Date.now()}`);
 		writeSession(buildSession());


### PR DESCRIPTION
Closes #36

## 問題

1. **ステータスが不安定**: agent 状態ファイルが `(cwd, session_id)` 単位だったため、サブエージェントのイベント(scratchpad や隔離 worktree など別 cwd で発火し、現行 Claude Code では `parent_tool_use_id` を持たず親と同じ `session_id` を共有する)が幽霊エントリを作り、サイドバーの表示がチラつく/実状態と一致しない
2. **通知が鳴らない**: グローバル ccdock の bun link が削除済み worktree を指す dangling symlink になり、全 hook が exit 127 で沈黙(気づく手段がなかった)

## 変更内容

- **agent 状態ファイルを session_id 単位に一本化**: サブエージェントのイベントは同一セッションの活動として同じファイルを更新。cwd がどのセッションにもマップしない場合は前回マップ済みの cwd を保持
- **旧形式(`<cwd>-<session_id>.json`)のマイグレーション**: `cleanStaleAgents` がセッションキー形式の twin を持つ旧ファイルを削除
- **hook 破損の起動時検知**: `~/.claude/settings.json` の ccdock hook コマンドが解決できない場合、TUI ヘッダー直下に警告バナーを表示
- **エージェント表示をアイコンから文字表記に戻す**(`✺`/`⬢` → `claude-code`/`codex`)

## 検証

- bun test: 94 pass / typecheck: 0 errors / format 適用済み
- 実環境で hook をこのブランチに link し、セッションキー形式での状態更新・通知復活・TUI 表示を動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)